### PR TITLE
#297488 - add query definition proxy endpoint

### DIFF
--- a/src/controllers/DataProviderController.ts
+++ b/src/controllers/DataProviderController.ts
@@ -153,6 +153,18 @@ export class DataProviderController {
     });
   }
 
+  public async getQueryDefinition(req: Request, res: Response) {
+    const creds = this.getCreds(req, res);
+    if (!creds) return;
+    const { queryId } = req.params;
+    const { teamProjectId = '' } = req.query as Record<string, string>;
+    await this.forward(res, `/azure/queries/${encodeURIComponent(queryId)}/definition`, {
+      orgUrl: creds.orgUrl,
+      token: creds.token,
+      teamProjectId,
+    });
+  }
+
   public async getHistoricalQueries(req: Request, res: Response) {
     const creds = this.getCreds(req, res);
     if (!creds) return;

--- a/src/routes/JsonDocRoutes.ts
+++ b/src/routes/JsonDocRoutes.ts
@@ -614,6 +614,9 @@ export class Routes {
       .route('/azure/queries/:queryId/results')
       .get((req: Request, res: Response) => this.dataProviderController.getQueryResults(req, res));
     app
+      .route('/azure/queries/:queryId/definition')
+      .get((req: Request, res: Response) => this.dataProviderController.getQueryDefinition(req, res));
+    app
       .route('/azure/queries/:queryId/historical-results')
       .get((req: Request, res: Response) =>
         this.dataProviderController.getHistoricalQueryResults(req, res),


### PR DESCRIPTION
Add GET /azure/queries/:queryId/definition route in JsonDocRoutes.ts. Add getQueryDefinition method in DataProviderController forwarding to content-control with orgUrl, token, teamProjectId.