### PR TITLE
 #309718 - SharePoint config, sync, and MinIO metadata overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ uploads/
 
 # Flat report local config (contains secrets)
 scripts/flat-report/flat-report.config.json
+docs/superpowers

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,7 +42,7 @@ export default class App {
         return callback(new Error(`CORS blocked for origin: ${origin}`));
       },
       methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-      allowedHeaders: ['Content-Type', 'X-Ado-Org-Url', 'X-Ado-PAT'],
+      allowedHeaders: ['Content-Type', 'X-Ado-Org-Url', 'X-Ado-PAT', 'X-User-Id'],
       optionsSuccessStatus: 204,
     };
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,8 @@ import cors, { CorsOptions } from 'cors';
 import { Routes } from './routes/JsonDocRoutes';
 import { injectRootSpan } from './helpers/openTracing/tracer-middleware';
 import multer from 'multer'; // Import multer
+import { getAllowedOrigins } from './util/authConfig';
+import logger from './util/logger';
 
 export default class App {
   public app: express.Application;
@@ -28,21 +30,36 @@ export default class App {
   }
 
   private createCorsOptions(): CorsOptions {
-    const allowedOrigins = String(process.env.CORS_ALLOWED_ORIGINS || '')
-      .split(',')
-      .map((origin) => origin.trim())
-      .filter(Boolean);
-    const allowAllOrigins = !allowedOrigins.length || allowedOrigins.includes('*');
+    // Unset/empty CORS_ALLOWED_ORIGINS means "trust no cross-origin
+    // request" — allow-all plus credentials:true below would be a
+    // session-theft hole for the SharePoint auth cookie.
+    let allowedOrigins: string[] = [];
+    try {
+      allowedOrigins = getAllowedOrigins();
+      if (allowedOrigins.length === 0) {
+        logger.warn(
+          'CORS_ALLOWED_ORIGINS is unset — all cross-origin browser requests will be blocked. Set it to the frontend origin(s) if the app is served from a different origin than this API.'
+        );
+      }
+    } catch (error) {
+      // Fail loud but not fatal at construction time (existing tests build
+      // `new App()` with no env at all) — assertAuthConfig() in server.ts
+      // is the actual boot-time hard stop for a genuinely misconfigured
+      // deployment.
+      logger.error(`Invalid CORS_ALLOWED_ORIGINS configuration: ${error.message}`);
+    }
+
     return {
       origin: (origin, callback) => {
         if (!origin) return callback(null, true);
-        if (allowAllOrigins || allowedOrigins.includes(origin)) {
+        if (allowedOrigins.includes(origin)) {
           return callback(null, true);
         }
         return callback(new Error(`CORS blocked for origin: ${origin}`));
       },
+      credentials: true,
       methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-      allowedHeaders: ['Content-Type', 'X-Ado-Org-Url', 'X-Ado-PAT', 'X-User-Id'],
+      allowedHeaders: ['Content-Type', 'X-Ado-Org-Url', 'X-Ado-PAT', 'X-User-Id', 'Authorization', 'X-Csrf-Token'],
       optionsSuccessStatus: 204,
     };
   }

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -1,0 +1,194 @@
+import { Request, Response } from 'express';
+import logger from '../util/logger';
+import { getAuthConfig, getAllowedOrigins } from '../util/authConfig';
+import {
+  parseCookieHeader,
+  sessionCookieName,
+  sessionCookieOptions,
+  clearedSessionCookieOptions,
+  csrfCookieName,
+  csrfCookieOptions,
+  clearedCsrfCookieOptions,
+  preAuthCookieName,
+  preAuthCookieOptions,
+  clearedPreAuthCookieOptions,
+} from '../util/cookies';
+import { timingSafeEqualStr } from '../util/randomTokens';
+import { buildCallbackPage } from '../util/authCallbackPage';
+import { createTransaction, consumeTransaction } from '../services/auth/OAuthTransactionService';
+import { buildAuthCodeUrl, redeemAuthCode } from '../services/auth/MsalClientService';
+import { assertIdTokenClaims } from '../services/auth/IdTokenValidator';
+import { createSession, revokeSession, issueHandleCode, consumeHandleCode } from '../services/auth/SessionService';
+
+const SESSION_MAX_AGE_MS = 8 * 60 * 60 * 1000; // matches AuthSession's absoluteExpiresAt cap
+
+export class AuthController {
+  // Starts the popup's Authorization Code + PKCE roundtrip. `opener` must be
+  // one of this deployment's own CORS origins — it becomes the postMessage
+  // target at /auth/callback, so it's never trusted blindly. `mode=ado`
+  // selects the bearer/handle-code transport for the ADO-embedded iframe;
+  // anything else uses the cookie transport.
+  public async login(req: Request, res: Response): Promise<void> {
+    const opener = typeof req.query.opener === 'string' ? req.query.opener : '';
+
+    let allowedOrigins: string[] = [];
+    try {
+      allowedOrigins = getAllowedOrigins();
+    } catch (error: any) {
+      logger.error(`/auth/login: invalid CORS_ALLOWED_ORIGINS configuration: ${error.message}`);
+    }
+
+    if (!opener || !allowedOrigins.includes(opener)) {
+      res.status(400).json({ success: false, error: 'invalid_opener_origin' });
+      return;
+    }
+
+    const transport = req.query.mode === 'ado' ? 'bearer' : 'cookie';
+
+    try {
+      const { state, codeVerifier, nonce } = await createTransaction({ openerOrigin: opener, transport });
+      res.cookie(preAuthCookieName, state, preAuthCookieOptions());
+      const authUrl = await buildAuthCodeUrl({ state, nonce, codeVerifier });
+      res.redirect(authUrl);
+    } catch (error: any) {
+      logger.error(`/auth/login failed: ${error.message}`);
+      res.status(500).json({ success: false, error: 'auth_login_failed' });
+    }
+  }
+
+  // The OAuth redirect target. `state` is checked (constant-time) against
+  // the pre-auth cookie before anything else — the login-CSRF defense: only
+  // the browser that started /auth/login holds that cookie, so an attacker
+  // can't complete their own sign-in and land it in a victim's session. Only
+  // once that passes and the transaction is consumed (single-use) is
+  // openerOrigin trustworthy enough to postMessage to; any earlier failure
+  // returns plain JSON instead.
+  public async callback(req: Request, res: Response): Promise<void> {
+    const state = typeof req.query.state === 'string' ? req.query.state : '';
+    if (!state) {
+      res.status(400).json({ success: false, error: 'missing_state' });
+      return;
+    }
+
+    const cookies = parseCookieHeader(req.headers.cookie);
+    const cookieState = cookies[preAuthCookieName];
+    if (!cookieState || !timingSafeEqualStr(state, cookieState)) {
+      res.status(400).json({ success: false, error: 'state_mismatch' });
+      return;
+    }
+
+    const transaction = await consumeTransaction(state);
+    if (!transaction) {
+      res.status(400).json({ success: false, error: 'invalid_or_expired_state' });
+      return;
+    }
+    res.clearCookie(preAuthCookieName, clearedPreAuthCookieOptions());
+
+    // From here on, transaction.openerOrigin is trustworthy (it was
+    // validated against the CORS allowlist at /auth/login time) — safe to
+    // use as the postMessage target for both success and failure.
+    try {
+      const oauthError = typeof req.query.error === 'string' ? req.query.error : '';
+      if (oauthError) {
+        // Send the stable short code (e.g. 'access_denied') separately from
+        // Entra's verbose error_description — the frontend maps friendly
+        // copy off the stable code and only falls back to the description
+        // for codes it doesn't recognize.
+        const description = typeof req.query.error_description === 'string' ? req.query.error_description : oauthError;
+        this.sendCallbackResult(res, transaction.openerOrigin, {
+          type: 'docgen:sp-auth',
+          ok: false,
+          error: oauthError,
+          errorDescription: description,
+        });
+        return;
+      }
+
+      const code = typeof req.query.code === 'string' ? req.query.code : '';
+      if (!code) {
+        this.sendCallbackResult(res, transaction.openerOrigin, { type: 'docgen:sp-auth', ok: false, error: 'missing_code' });
+        return;
+      }
+
+      const authResult = await redeemAuthCode({ code, codeVerifier: transaction.codeVerifier, state });
+      const { clientId, tenantId } = getAuthConfig();
+      assertIdTokenClaims((authResult.idTokenClaims as any) || {}, { nonce: transaction.nonce, tenantId, clientId });
+
+      const homeAccountId = authResult.account?.homeAccountId;
+      if (!homeAccountId) {
+        throw new Error('MSAL did not return an account for the redeemed code');
+      }
+
+      const { sessionToken, csrfToken } = await createSession({
+        homeAccountId,
+        transport: transaction.transport,
+        displayName: authResult.account?.name,
+        userPrincipalName: authResult.account?.username,
+        tenantId: authResult.account?.tenantId,
+      });
+
+      if (transaction.transport === 'bearer') {
+        const handleCode = await issueHandleCode(sessionToken);
+        this.sendCallbackResult(res, transaction.openerOrigin, { type: 'docgen:sp-auth', ok: true, handleCode });
+      } else {
+        res.cookie(sessionCookieName, sessionToken, sessionCookieOptions(SESSION_MAX_AGE_MS));
+        res.cookie(csrfCookieName, csrfToken, csrfCookieOptions(SESSION_MAX_AGE_MS));
+        this.sendCallbackResult(res, transaction.openerOrigin, { type: 'docgen:sp-auth', ok: true });
+      }
+    } catch (error: any) {
+      logger.error(`/auth/callback failed after a valid state: ${error.message}`);
+      this.sendCallbackResult(res, transaction.openerOrigin, { type: 'docgen:sp-auth', ok: false, error: 'sign_in_failed' });
+    }
+  }
+
+  private sendCallbackResult(
+    res: Response,
+    targetOrigin: string,
+    payload: { type: 'docgen:sp-auth'; ok: boolean; handleCode?: string; error?: string; errorDescription?: string }
+  ): void {
+    const page = buildCallbackPage({ targetOrigin, payload });
+    res.set(page.headers).status(200).send(page.html);
+  }
+
+  // Bearer-transport only: exchanges the one-time handle code (delivered
+  // via postMessage) for the actual bearer session token. No requireSession
+  // guard on this route — the handle code itself is the one-time
+  // credential that authorizes this exchange.
+  public async exchangeSessionHandle(req: Request, res: Response): Promise<void> {
+    const handleCode = typeof req.body?.handleCode === 'string' ? req.body.handleCode : '';
+    if (!handleCode) {
+      res.status(400).json({ success: false, error: 'missing_handle_code' });
+      return;
+    }
+
+    const result = await consumeHandleCode(handleCode);
+    if (!result) {
+      res.status(400).json({ success: false, error: 'invalid_or_expired_handle_code' });
+      return;
+    }
+
+    res.status(200).json({ success: true, sessionToken: result.sessionToken });
+  }
+
+  // Returns display-name/UPN sourced from the ID token claims captured at
+  // sign-in — never a fresh Graph /me call, which is why User.Read is not
+  // among this app's requested scopes.
+  public async getSessionInfo(req: Request, res: Response): Promise<void> {
+    const session = (req as any).spSession;
+    res.status(200).json({
+      success: true,
+      displayName: session?.displayName,
+      userPrincipalName: session?.userPrincipalName,
+    });
+  }
+
+  public async logout(req: Request, res: Response): Promise<void> {
+    const rawToken = (req as any).spSessionRawToken;
+    if (rawToken) {
+      await revokeSession(rawToken);
+    }
+    res.clearCookie(sessionCookieName, clearedSessionCookieOptions());
+    res.clearCookie(csrfCookieName, clearedCsrfCookieOptions());
+    res.status(200).json({ success: true });
+  }
+}

--- a/src/controllers/DataProviderController.ts
+++ b/src/controllers/DataProviderController.ts
@@ -109,6 +109,17 @@ export class DataProviderController {
     await this.forward(res, '/azure/user/profile', { orgUrl: creds.orgUrl, token: creds.token });
   }
 
+  public async getWindowsIdentity(req: Request, res: Response) {
+    const creds = this.getCreds(req, res);
+    if (!creds) return;
+    const identityId = String(req.query.identityId || '').trim();
+    await this.forward(res, '/azure/user/windows-identity', {
+      orgUrl: creds.orgUrl,
+      token: creds.token,
+      identityId,
+    });
+  }
+
   public async getCollectionLinkTypes(req: Request, res: Response) {
     const creds = this.getCreds(req, res);
     if (!creds) return;

--- a/src/controllers/MinioController.ts
+++ b/src/controllers/MinioController.ts
@@ -195,7 +195,7 @@ export class MinioController {
         return reject('No file provided');
       }
 
-      const { docType, teamProjectName, isExternalUrl, createdBy, createdById } = req.body;
+      const { docType, teamProjectName, isExternalUrl, createdBy, createdById, sourceLastModified } = req.body;
       let { bucketName } = req.body;
       const uploadPurpose = String(req.body?.purpose || '')
         .trim()
@@ -283,6 +283,12 @@ export class MinioController {
         const safeCreatedById = this.encodeMetadataHeaderValue(createdById, 256);
         if (safeCreatedById) {
           uploadMetadata.createdById = safeCreatedById;
+        }
+      }
+      if (String(sourceLastModified || '').trim()) {
+        const safeSourceLastModified = this.encodeMetadataHeaderValue(sourceLastModified, 64);
+        if (safeSourceLastModified) {
+          uploadMetadata.sourceLastModified = safeSourceLastModified;
         }
       }
       // Ensure the bucket exists before uploading the file
@@ -707,6 +713,14 @@ export class MinioController {
                 'inputdetails',
               ]),
             );
+            obj.sourceLastModified = this.decodeMetadataHeaderValue(
+              this.getFirstMetadataValue(metaData, [
+                'sourceLastModified',
+                'sourcelastmodified',
+                'x-amz-meta-sourceLastModified',
+                'x-amz-meta-sourcelastmodified',
+              ]),
+            );
           }
         } catch (error) {
           logger.error(`Error fetching metadata for ${obj.name}:`, error);
@@ -714,6 +728,7 @@ export class MinioController {
           obj.createdById = '';
           obj.inputSummary = '';
           obj.inputDetailsKey = '';
+          obj.sourceLastModified = '';
         }
         objects.push(obj);
       })();

--- a/src/controllers/SharePointController.ts
+++ b/src/controllers/SharePointController.ts
@@ -1,9 +1,19 @@
 import { Request, Response } from 'express';
-import { SharePointService, SharePointConfig as SharePointConfigType } from '../services/SharePointService';
+import {
+  SharePointService,
+  SharePointConfig as SharePointConfigType,
+  SharePointCredentials,
+  isSharePointOnlineUrl,
+} from '../services/SharePointService';
 import { MinioController } from './MinioController';
 import logger from '../util/logger';
 import { getMinioFiles } from '../helpers/sharePointHelpers/sharePointHelper';
 import { SharePointConfig as ConfigModel } from '../models/SharePointConfig';
+import { createTokenProvider, GraphTokenProvider } from '../services/auth/MsalClientService';
+import { classifySharePointUrl } from '../util/sharePointLinkClassifier';
+
+type ResolvedAuth = SharePointCredentials | GraphTokenProvider;
+type AuthResolution = { auth: ResolvedAuth } | { error: { status: number; message: string } };
 
 // Kept in sync with the toast in TemplatesTab.jsx and docs/wiki/SharePoint_Sync_Guide.txt.
 // 'MEETING-SUMMARY' matches MEETING_SUMMARY_DOC_TYPE in meetingSummaryUtils.js — the
@@ -25,25 +35,65 @@ export class SharePointController {
   }
 
   /**
+   * Turns a request's body/session into the auth value SharePointService
+   * needs. Online authenticates exclusively via the BFF session
+   * (attachSessionIfPresent populates req.spSession — see JsonDocRoutes.ts);
+   * a client-supplied `oauthToken` is rejected outright, never silently
+   * ignored. On-prem NTLM is untouched: `credentials` in the body, no
+   * session, since these routes are dual-purpose and on-prem callers never
+   * authenticate via /auth/login.
+   */
+  private resolveAuth(req: Request, siteUrl: string): AuthResolution {
+    const { credentials, oauthToken } = req.body;
+
+    if (oauthToken) {
+      return { error: { status: 400, message: 'oauth_token_not_accepted' } };
+    }
+
+    if (isSharePointOnlineUrl(siteUrl)) {
+      const session = (req as any).spSession as { homeAccountId: string } | undefined;
+      if (!session) {
+        return { error: { status: 401, message: 'reauth_required' } };
+      }
+      return { auth: createTokenProvider(session.homeAccountId) };
+    }
+
+    if (!credentials) {
+      return { error: { status: 400, message: 'Missing required fields' } };
+    }
+    return { auth: credentials };
+  }
+
+  /**
    * Test SharePoint connection
    * POST /sharepoint/test-connection
-   * Body: { siteUrl, library, folder, credentials?: { username, password, domain? }, oauthToken?: { accessToken } }
+   * Body: { siteUrl, library, folder, credentials?: { username, password, domain? } } — Online authenticates via the BFF session, not a body field.
    */
   public async testConnection(req: Request, res: Response): Promise<void> {
     try {
-      const { siteUrl, library, folder, credentials, oauthToken } = req.body;
+      const { siteUrl, library, folder } = req.body;
+
+      if (!siteUrl) {
+        res.status(400).json({ success: false, message: 'Missing required fields' });
+        return;
+      }
+
+      const authResult = this.resolveAuth(req, siteUrl);
+      if ('error' in authResult) {
+        res.status(authResult.error.status).json({ success: false, message: authResult.error.message });
+        return;
+      }
 
       // library/folder are only meaningful for on-prem (NTLM) configs — an
       // Online config's siteUrl is itself the pasted sharing/folder link,
       // so library/folder are legitimately empty there.
-      if (!siteUrl || (!credentials && !oauthToken) || (!oauthToken && !folder)) {
+      if (!isSharePointOnlineUrl(siteUrl) && !folder) {
         res.status(400).json({ success: false, message: 'Missing required fields' });
         return;
       }
 
       const config: SharePointConfigType = { siteUrl, library, folder };
-      const auth = oauthToken || credentials;
-      const result = await this.sharePointService.testConnection(config, auth);
+      const result = await this.sharePointService.testConnection(config, authResult.auth);
 
       res.status(200).json(result);
     } catch (error: any) {
@@ -82,20 +132,33 @@ export class SharePointController {
   /**
    * List template files from SharePoint folder
    * POST /sharepoint/list-files
-   * Body: { siteUrl, library, folder, credentials?, oauthToken? }
+   * Body: { siteUrl, library, folder, credentials? } — Online authenticates via the BFF session, not a body field.
    */
   public async listFiles(req: Request, res: Response): Promise<void> {
     try {
-      const { siteUrl, library, folder, credentials, oauthToken } = req.body;
+      const { siteUrl, library, folder } = req.body;
 
-      if (!siteUrl || (!credentials && !oauthToken) || (!oauthToken && !folder)) {
+      if (!siteUrl) {
+        res.status(400).json({ success: false, message: 'Missing required fields' });
+        return;
+      }
+
+      const authResult = this.resolveAuth(req, siteUrl);
+      if ('error' in authResult) {
+        res.status(authResult.error.status).json({ success: false, message: authResult.error.message });
+        return;
+      }
+
+      if (!isSharePointOnlineUrl(siteUrl) && !folder) {
         res.status(400).json({ success: false, message: 'Missing required fields' });
         return;
       }
 
       const config: SharePointConfigType = { siteUrl, library, folder };
-      const auth = oauthToken || credentials;
-      const { files, truncated, skippedFolders = [] } = await this.sharePointService.listTemplateFiles(config, auth);
+      const { files, truncated, skippedFolders = [] } = await this.sharePointService.listTemplateFiles(
+        config,
+        authResult.auth
+      );
       if (skippedFolders.length > 0) {
         logger.warn(`Skipped ${skippedFolders.length} inaccessible folder(s) while listing files`);
       }
@@ -110,20 +173,24 @@ export class SharePointController {
   /**
    * Check for file conflicts before syncing
    * POST /sharepoint/check-conflicts
-   * Body: { siteUrl, library, folder, credentials?, oauthToken?, bucketName, projectName, docType }
+   * Body: { siteUrl, library, folder, credentials?, bucketName, projectName, docType } — Online authenticates via the BFF session, not a body field.
    */
   public async checkConflicts(req: Request, res: Response): Promise<void> {
     try {
-      const { siteUrl, library, folder, credentials, oauthToken, bucketName, projectName, docType, docTypeOverrides } =
-        req.body;
+      const { siteUrl, library, folder, bucketName, projectName, docType, docTypeOverrides } = req.body;
 
-      if (
-        !siteUrl ||
-        (!credentials && !oauthToken) ||
-        (!oauthToken && !folder) ||
-        !bucketName ||
-        !projectName
-      ) {
+      if (!siteUrl || !bucketName || !projectName) {
+        res.status(400).json({ success: false, message: 'Missing required fields' });
+        return;
+      }
+
+      const authResult = this.resolveAuth(req, siteUrl);
+      if ('error' in authResult) {
+        res.status(authResult.error.status).json({ success: false, message: authResult.error.message });
+        return;
+      }
+
+      if (!isSharePointOnlineUrl(siteUrl) && !folder) {
         res.status(400).json({ success: false, message: 'Missing required fields' });
         return;
       }
@@ -139,7 +206,6 @@ export class SharePointController {
       }
 
       const config: SharePointConfigType = { siteUrl, library, folder };
-      const auth = oauthToken || credentials;
 
       // Get files from SharePoint, recursively (includes docType from the
       // immediate parent folder name, when there is one)
@@ -147,7 +213,7 @@ export class SharePointController {
         files: spFiles,
         truncated,
         skippedFolders = [],
-      } = await this.sharePointService.listTemplateFiles(config, auth);
+      } = await this.sharePointService.listTemplateFiles(config, authResult.auth);
       logger.info(`Checking ${spFiles.length} SharePoint files for conflicts${truncated ? ' (listing truncated)' : ''}`);
       if (skippedFolders.length > 0) {
         logger.warn(`Skipped ${skippedFolders.length} inaccessible folder(s) while checking conflicts`);
@@ -259,30 +325,25 @@ export class SharePointController {
   /**
    * Sync templates from SharePoint to MinIO
    * POST /sharepoint/sync-templates
-   * Body: { siteUrl, library, folder, credentials?, oauthToken?, bucketName, projectName, docType, skipFiles? }
+   * Body: { siteUrl, library, folder, credentials?, bucketName, projectName, docType, skipFiles? } — Online authenticates via the BFF session, not a body field.
    */
   public async syncTemplates(req: Request, res: Response): Promise<void> {
     try {
-      const {
-        siteUrl,
-        library,
-        folder,
-        credentials,
-        oauthToken,
-        bucketName,
-        projectName,
-        docType,
-        skipFiles,
-        docTypeOverrides,
-      } = req.body;
+      const { siteUrl, library, folder, bucketName, projectName, docType, skipFiles, docTypeOverrides } = req.body;
 
-      if (
-        !siteUrl ||
-        (!credentials && !oauthToken) ||
-        (!oauthToken && !folder) ||
-        !bucketName ||
-        !projectName
-      ) {
+      if (!siteUrl || !bucketName || !projectName) {
+        res.status(400).json({ success: false, message: 'Missing required fields' });
+        return;
+      }
+
+      const authResult = this.resolveAuth(req, siteUrl);
+      if ('error' in authResult) {
+        res.status(authResult.error.status).json({ success: false, message: authResult.error.message });
+        return;
+      }
+      const auth = authResult.auth;
+
+      if (!isSharePointOnlineUrl(siteUrl) && !folder) {
         res.status(400).json({ success: false, message: 'Missing required fields' });
         return;
       }
@@ -298,7 +359,6 @@ export class SharePointController {
       }
 
       const config: SharePointConfigType = { siteUrl, library, folder };
-      const auth = oauthToken || credentials;
 
       // Get all template files from SharePoint, recursively
       const {
@@ -587,7 +647,23 @@ export class SharePointController {
         // Update last used
         config.lastUsed = new Date();
         await config.save();
-        res.status(200).json({ success: true, config });
+
+        // A row already confirmed (authType + linkResolvedAt persisted, e.g.
+        // from a prior successful sync) is trusted as-is; anything else is
+        // classified fresh on every read. Optimistic, not authoritative —
+        // only testConnection's actual /shares resolution can truly confirm
+        // or invalidate it.
+        const classification = config.authType && config.linkResolvedAt
+          ? 'trusted'
+          : classifySharePointUrl({ siteUrl: config.siteUrl, library: config.library, folder: config.folder });
+        const requiresRelink = classification === 'online-legacy-site-path';
+
+        res.status(200).json({
+          success: true,
+          config,
+          requiresRelink,
+          relinkReason: requiresRelink ? 'legacy-site-path' : null,
+        });
       } else {
         res.status(404).json({ success: false, message: 'No configuration found' });
       }

--- a/src/controllers/SharePointController.ts
+++ b/src/controllers/SharePointController.ts
@@ -5,7 +5,12 @@ import logger from '../util/logger';
 import { getMinioFiles } from '../helpers/sharePointHelpers/sharePointHelper';
 import { SharePointConfig as ConfigModel } from '../models/SharePointConfig';
 
-const VALID_TEMPLATE_DOC_TYPES = ['STD', 'STP', 'STR', 'SVD', 'SRS', 'SYSRS'] as const;
+// Kept in sync with the toast in TemplatesTab.jsx and docs/wiki/SharePoint_Sync_Guide.txt.
+// 'MEETING-SUMMARY' matches MEETING_SUMMARY_DOC_TYPE in meetingSummaryUtils.js — the
+// isValidTemplateDocType check below uppercases the subfolder name before comparing,
+// but the original subfolder casing ("Meeting-Summary") is preserved as the docType
+// used for the MinIO path.
+const VALID_TEMPLATE_DOC_TYPES = ['STD', 'STP', 'STR', 'SVD', 'SRS', 'SYSRS', 'MEETING-SUMMARY'] as const;
 
 const isValidTemplateDocType = (docType: string) =>
   VALID_TEMPLATE_DOC_TYPES.includes((docType || '').toUpperCase() as (typeof VALID_TEMPLATE_DOC_TYPES)[number]);
@@ -28,7 +33,10 @@ export class SharePointController {
     try {
       const { siteUrl, library, folder, credentials, oauthToken } = req.body;
 
-      if (!siteUrl || !library || !folder || (!credentials && !oauthToken)) {
+      // library/folder are only meaningful for on-prem (NTLM) configs — an
+      // Online config's siteUrl is itself the pasted sharing/folder link,
+      // so library/folder are legitimately empty there.
+      if (!siteUrl || (!credentials && !oauthToken) || (!oauthToken && !folder)) {
         res.status(400).json({ success: false, message: 'Missing required fields' });
         return;
       }
@@ -40,7 +48,34 @@ export class SharePointController {
       res.status(200).json(result);
     } catch (error: any) {
       logger.error(`Test connection error: ${error.message}`);
-      res.status(500).json({ success: false, message: error.message });
+      res.status(error.status || 500).json({ success: false, message: error.message });
+    }
+  }
+
+  /**
+   * Resolves a pasted on-prem templates-folder URL (copied from the browser
+   * address bar) into a ready-to-save { siteUrl, library, folder } — lets
+   * the connect dialog take one pasted URL instead of three typed fields.
+   * On-prem/NTLM only: Online configs already work off one pasted sharing
+   * link with no server-side resolution needed.
+   * POST /sharepoint/resolve-url
+   * Body: { url, credentials: { username, password, domain? } }
+   */
+  public async resolveUrl(req: Request, res: Response): Promise<void> {
+    try {
+      const { url, credentials } = req.body;
+
+      if (!url || !credentials) {
+        res.status(400).json({ success: false, message: 'Missing required fields' });
+        return;
+      }
+
+      const resolved = await this.sharePointService.resolveSiteFromUrl(url, credentials);
+
+      res.status(200).json({ success: true, ...resolved });
+    } catch (error: any) {
+      logger.error(`Resolve URL error: ${error.message}`);
+      res.status(error.status || 500).json({ success: false, message: error.message });
     }
   }
 
@@ -53,7 +88,7 @@ export class SharePointController {
     try {
       const { siteUrl, library, folder, credentials, oauthToken } = req.body;
 
-      if (!siteUrl || !library || !folder || (!credentials && !oauthToken)) {
+      if (!siteUrl || (!credentials && !oauthToken) || (!oauthToken && !folder)) {
         res.status(400).json({ success: false, message: 'Missing required fields' });
         return;
       }
@@ -65,7 +100,7 @@ export class SharePointController {
       res.status(200).json({ success: true, files });
     } catch (error: any) {
       logger.error(`List files error: ${error.message}`);
-      res.status(500).json({ success: false, message: error.message });
+      res.status(error.status || 500).json({ success: false, message: error.message });
     }
   }
 
@@ -79,8 +114,24 @@ export class SharePointController {
       const { siteUrl, library, folder, credentials, oauthToken, bucketName, projectName, docType } =
         req.body;
 
-      if (!siteUrl || !library || !folder || (!credentials && !oauthToken) || !bucketName || !projectName) {
+      if (
+        !siteUrl ||
+        (!credentials && !oauthToken) ||
+        (!oauthToken && !folder) ||
+        !bucketName ||
+        !projectName
+      ) {
         res.status(400).json({ success: false, message: 'Missing required fields' });
+        return;
+      }
+
+      // Templates only ever sync into a real team project's bucket path —
+      // 'shared' (the standard/shared-templates library sentinel) is not a
+      // valid sync target, enforced here too, not just in the UI.
+      if (projectName === 'shared') {
+        res
+          .status(400)
+          .json({ success: false, message: 'A team project must be selected to sync templates' });
         return;
       }
 
@@ -143,6 +194,8 @@ export class SharePointController {
               name: spFile.name,
               size: spFile.length,
               docType: targetDocType,
+              timeCreated: spFile.timeCreated,
+              timeLastModified: spFile.timeLastModified,
               existingSize: existingFile.size,
               sizeChanged: true,
             });
@@ -158,6 +211,8 @@ export class SharePointController {
             name: spFile.name,
             size: spFile.length,
             docType: targetDocType,
+            timeCreated: spFile.timeCreated,
+            timeLastModified: spFile.timeLastModified,
           });
         }
       }
@@ -175,7 +230,7 @@ export class SharePointController {
       });
     } catch (error: any) {
       logger.error(`Check conflicts error: ${error.message}`);
-      res.status(500).json({ success: false, message: error.message });
+      res.status(error.status || 500).json({ success: false, message: error.message });
     }
   }
 
@@ -198,8 +253,24 @@ export class SharePointController {
         skipFiles,
       } = req.body;
 
-      if (!siteUrl || !library || !folder || (!credentials && !oauthToken) || !bucketName || !projectName) {
+      if (
+        !siteUrl ||
+        (!credentials && !oauthToken) ||
+        (!oauthToken && !folder) ||
+        !bucketName ||
+        !projectName
+      ) {
         res.status(400).json({ success: false, message: 'Missing required fields' });
+        return;
+      }
+
+      // Templates only ever sync into a real team project's bucket path —
+      // 'shared' (the standard/shared-templates library sentinel) is not a
+      // valid sync target, enforced here too, not just in the UI.
+      if (projectName === 'shared') {
+        res
+          .status(400)
+          .json({ success: false, message: 'A team project must be selected to sync templates' });
         return;
       }
 
@@ -328,6 +399,10 @@ export class SharePointController {
               teamProjectName: projectName,
               docType: targetDocType,
               isExternal: false,
+              // Real SharePoint modified date — persisted as object metadata so the
+              // Templates tab shows when the template actually changed, not when
+              // MinIO happened to store it.
+              sourceLastModified: file.timeLastModified,
             },
           };
 
@@ -351,7 +426,7 @@ export class SharePointController {
       res.status(200).json(syncResults);
     } catch (error: any) {
       logger.error(`Sync templates error: ${error.message}`);
-      res.status(500).json({ success: false, message: error.message });
+      res.status(error.status || 500).json({ success: false, message: error.message });
     }
   }
 
@@ -361,15 +436,30 @@ export class SharePointController {
    */
   public async saveConfig(req: Request, res: Response): Promise<void> {
     try {
-      const { userId, projectName, siteUrl, library, folder, displayName } = req.body;
+      const { userId, siteUrl, library, folder, displayName } = req.body;
 
-      if (!siteUrl || !library || !folder) {
+      // library/folder are only meaningful for on-prem configs; an Online
+      // config's siteUrl is itself the pasted sharing/folder link, and even
+      // the on-prem paste-a-URL flow (resolveSiteFromUrl) leaves library
+      // blank (the whole path lands in folder). Neither is reliably
+      // required anymore — siteUrl is the only field every config needs.
+      if (!siteUrl) {
         res.status(400).json({ success: false, message: 'Missing required fields' });
         return;
       }
 
-      // Find existing config or create new
-      let config = await ConfigModel.findOne({ userId, projectName });
+      // userId must be a non-empty string, not just truthy — a missing/typed
+      // value would otherwise make the findOne below match {} (any user's
+      // config), and a JSON body lets userId be an object/query operator.
+      if (typeof userId !== 'string' || !userId.trim()) {
+        res.status(400).json({ success: false, message: 'userId is required' });
+        return;
+      }
+
+      // The SharePoint connection is app-level, not per-project: one saved
+      // config per user, usable no matter which (if any) team project is
+      // selected. Only the eventual sync target is project-scoped.
+      let config = await ConfigModel.findOne({ userId });
 
       if (config) {
         // Update existing
@@ -383,7 +473,6 @@ export class SharePointController {
         // Create new
         config = new ConfigModel({
           userId,
-          projectName,
           siteUrl,
           library,
           folder,
@@ -395,25 +484,28 @@ export class SharePointController {
       res.status(200).json({ success: true, config });
     } catch (error: any) {
       logger.error(`Save config error: ${error.message}`);
-      res.status(500).json({ success: false, message: error.message });
+      res.status(error.status || 500).json({ success: false, message: error.message });
     }
   }
 
   /**
-   * Get SharePoint configuration
-   * GET /sharepoint/config?projectName=xxx
+   * Get the app-level SharePoint configuration for a user
+   * GET /sharepoint/config
    * Headers: X-User-Id
    */
   public async getConfig(req: Request, res: Response): Promise<void> {
     try {
-      const userId = req.headers['x-user-id'] as string;
-      const { projectName } = req.query;
+      const userId = req.headers['x-user-id'];
 
-      const query: any = {};
-      if (userId) query.userId = userId;
-      if (projectName) query.projectName = projectName;
+      // userId must be present, and a single string — a missing/absent
+      // header must not degrade into findOne({}), which would return
+      // (and touch the lastUsed of) an arbitrary other user's config.
+      if (typeof userId !== 'string' || !userId.trim()) {
+        res.status(400).json({ success: false, message: 'userId is required in headers' });
+        return;
+      }
 
-      const config = await ConfigModel.findOne(query).sort({ lastUsed: -1 });
+      const config = await ConfigModel.findOne({ userId }).sort({ lastUsed: -1 });
 
       if (config) {
         // Update last used
@@ -425,7 +517,7 @@ export class SharePointController {
       }
     } catch (error: any) {
       logger.error(`Get config error: ${error.message}`);
-      res.status(500).json({ success: false, message: error.message });
+      res.status(error.status || 500).json({ success: false, message: error.message });
     }
   }
 
@@ -448,7 +540,7 @@ export class SharePointController {
       res.status(200).json({ success: true, configs });
     } catch (error: any) {
       logger.error(`Get configs error: ${error.message}`);
-      res.status(500).json({ success: false, message: error.message });
+      res.status(error.status || 500).json({ success: false, message: error.message });
     }
   }
 
@@ -471,37 +563,36 @@ export class SharePointController {
       res.status(200).json({ success: true, configs });
     } catch (error: any) {
       logger.error(`Get all configs error: ${error.message}`);
-      res.status(500).json({ success: false, message: error.message });
+      res.status(error.status || 500).json({ success: false, message: error.message });
     }
   }
 
   /**
-   * Delete SharePoint configuration for a project
-   * DELETE /sharepoint/config?projectName=xxx
+   * Delete the app-level SharePoint configuration for a user
+   * DELETE /sharepoint/config
    * Headers: X-User-Id
    */
   public async deleteConfig(req: Request, res: Response): Promise<void> {
     try {
       const userId = req.headers['x-user-id'] as string;
-      const { projectName } = req.query;
 
-      if (!userId || !projectName) {
-        res.status(400).json({ success: false, message: 'userId and projectName are required' });
+      if (!userId) {
+        res.status(400).json({ success: false, message: 'userId is required' });
         return;
       }
 
-      const result = await ConfigModel.deleteOne({ userId, projectName: projectName as string });
+      const result = await ConfigModel.deleteOne({ userId });
 
       if (result.deletedCount === 0) {
         res.status(404).json({ success: false, message: 'Configuration not found' });
         return;
       }
 
-      logger.info(`Deleted SharePoint config for user ${userId}, project ${projectName}`);
+      logger.info(`Deleted SharePoint config for user ${userId}`);
       res.status(200).json({ success: true, message: 'Configuration deleted successfully' });
     } catch (error: any) {
       logger.error(`Delete config error: ${error.message}`);
-      res.status(500).json({ success: false, message: error.message });
+      res.status(error.status || 500).json({ success: false, message: error.message });
     }
   }
 }

--- a/src/controllers/SharePointController.ts
+++ b/src/controllers/SharePointController.ts
@@ -95,9 +95,12 @@ export class SharePointController {
 
       const config: SharePointConfigType = { siteUrl, library, folder };
       const auth = oauthToken || credentials;
-      const files = await this.sharePointService.listTemplateFiles(config, auth);
+      const { files, truncated, skippedFolders = [] } = await this.sharePointService.listTemplateFiles(config, auth);
+      if (skippedFolders.length > 0) {
+        logger.warn(`Skipped ${skippedFolders.length} inaccessible folder(s) while listing files`);
+      }
 
-      res.status(200).json({ success: true, files });
+      res.status(200).json({ success: true, files, truncated, skippedFolders });
     } catch (error: any) {
       logger.error(`List files error: ${error.message}`);
       res.status(error.status || 500).json({ success: false, message: error.message });
@@ -111,7 +114,7 @@ export class SharePointController {
    */
   public async checkConflicts(req: Request, res: Response): Promise<void> {
     try {
-      const { siteUrl, library, folder, credentials, oauthToken, bucketName, projectName, docType } =
+      const { siteUrl, library, folder, credentials, oauthToken, bucketName, projectName, docType, docTypeOverrides } =
         req.body;
 
       if (
@@ -138,9 +141,17 @@ export class SharePointController {
       const config: SharePointConfigType = { siteUrl, library, folder };
       const auth = oauthToken || credentials;
 
-      // Get files from SharePoint (includes docType from subfolder names)
-      const spFiles = await this.sharePointService.listTemplateFiles(config, auth);
-      logger.info(`Checking ${spFiles.length} SharePoint files for conflicts`);
+      // Get files from SharePoint, recursively (includes docType from the
+      // immediate parent folder name, when there is one)
+      const {
+        files: spFiles,
+        truncated,
+        skippedFolders = [],
+      } = await this.sharePointService.listTemplateFiles(config, auth);
+      logger.info(`Checking ${spFiles.length} SharePoint files for conflicts${truncated ? ' (listing truncated)' : ''}`);
+      if (skippedFolders.length > 0) {
+        logger.warn(`Skipped ${skippedFolders.length} inaccessible folder(s) while checking conflicts`);
+      }
 
       // Group files by docType for conflict checking
       const conflicts: any[] = [];
@@ -148,15 +159,22 @@ export class SharePointController {
       const invalidFiles: any[] = [];
 
       for (const spFile of spFiles) {
-        const targetDocType = spFile.docType || docType || '';
+        const targetDocType = docTypeOverrides?.[spFile.relativePath] || spFile.docType || docType || '';
 
-        // Skip files with invalid docType
+        // A file with no auto-detected (or already-invalid) docType is no
+        // longer hard-rejected here — it's surfaced as a reviewable row
+        // with an empty docType so the review dialog can let the user
+        // manually assign one via a per-row selector. `invalidFiles` is
+        // kept for defensive symmetry but should rarely populate now.
         if (!targetDocType || !isValidTemplateDocType(targetDocType)) {
-          invalidFiles.push({
+          newFiles.push({
             name: spFile.name,
+            relativePath: spFile.relativePath,
             size: spFile.length,
-            docType: targetDocType || 'none',
-            error: `Invalid docType "${targetDocType}". Valid types are: ${VALID_TEMPLATE_DOC_TYPES.join(', ')}`,
+            docType: '',
+            timeCreated: spFile.timeCreated,
+            timeLastModified: spFile.timeLastModified,
+            needsDocType: true,
           });
           continue;
         }
@@ -192,6 +210,7 @@ export class SharePointController {
 
             conflicts.push({
               name: spFile.name,
+              relativePath: spFile.relativePath,
               size: spFile.length,
               docType: targetDocType,
               timeCreated: spFile.timeCreated,
@@ -209,6 +228,7 @@ export class SharePointController {
 
           newFiles.push({
             name: spFile.name,
+            relativePath: spFile.relativePath,
             size: spFile.length,
             docType: targetDocType,
             timeCreated: spFile.timeCreated,
@@ -227,6 +247,8 @@ export class SharePointController {
         conflicts,
         newFiles,
         invalidFiles,
+        truncated,
+        skippedFolders,
       });
     } catch (error: any) {
       logger.error(`Check conflicts error: ${error.message}`);
@@ -251,6 +273,7 @@ export class SharePointController {
         projectName,
         docType,
         skipFiles,
+        docTypeOverrides,
       } = req.body;
 
       if (
@@ -277,16 +300,28 @@ export class SharePointController {
       const config: SharePointConfigType = { siteUrl, library, folder };
       const auth = oauthToken || credentials;
 
-      // Get all template files from SharePoint
-      const allFiles = await this.sharePointService.listTemplateFiles(config, auth);
+      // Get all template files from SharePoint, recursively
+      const {
+        files: allFiles,
+        truncated,
+        skippedFolders = [],
+      } = await this.sharePointService.listTemplateFiles(config, auth);
+      if (truncated) {
+        logger.warn('SharePoint template listing was truncated (depth/count cap) — syncing only what was listed');
+      }
+      if (skippedFolders.length > 0) {
+        logger.warn(`Skipped ${skippedFolders.length} inaccessible folder(s) while syncing templates`);
+      }
 
-      // Filter out files user wants to skip (from conflict dialog)
-      let filesToSync = allFiles.filter((f) => !skipFiles || !skipFiles.includes(f.name));
+      // Filter out files user wants to skip (from conflict dialog). Keyed by
+      // relativePath, not name — recursion permits duplicate basenames in
+      // different folders, which a name-only key can't tell apart.
+      let filesToSync = allFiles.filter((f) => !skipFiles || !skipFiles.includes(f.relativePath));
 
       // Also skip identical files (same size as existing files in MinIO)
-      const identicalFiles: string[] = [];
+      const identicalFiles: string[] = []; // relativePaths
       for (const file of filesToSync) {
-        const targetDocType = file.docType || docType || '';
+        const targetDocType = docTypeOverrides?.[file.relativePath] || file.docType || docType || '';
         if (!targetDocType) continue;
 
         try {
@@ -305,7 +340,7 @@ export class SharePointController {
 
           if (existingFile && Number(existingFile.size) === Number(file.length)) {
             // Identical file - skip it
-            identicalFiles.push(file.name);
+            identicalFiles.push(file.relativePath);
             logger.debug(`Skipping identical: ${file.name} (size: ${file.length})`);
           }
         } catch (error) {
@@ -314,12 +349,49 @@ export class SharePointController {
       }
 
       // Remove identical files from sync list
-      filesToSync = filesToSync.filter((f) => !identicalFiles.includes(f.name));
+      filesToSync = filesToSync.filter((f) => !identicalFiles.includes(f.relativePath));
+
+      // Recursion permits duplicate basenames living in different
+      // SharePoint folders (e.g. "STD-template.dotx" under two different
+      // subfolders) — the MinIO destination is only bucket/project/docType/
+      // <basename>, not relativePath, so two files manually mapped (or
+      // bulk-assigned from the review dialog) to the same docType would
+      // silently overwrite each other with no indication anything was
+      // lost. Detect this before any download/upload happens: keep the
+      // first file for each destination, fail the rest with a clear reason
+      // instead of a silent overwrite.
+      const destinationKeyOf = (file: (typeof filesToSync)[number]) => {
+        const targetDocType = docTypeOverrides?.[file.relativePath] || file.docType || docType || '';
+        const baseName = file.name.split('/').pop() || file.name;
+        return `${targetDocType}/${baseName}`;
+      };
+      const seenDestinations = new Map<string, string>(); // destinationKey -> first file's relativePath
+      const duplicateDestinationPaths = new Set<string>();
+      const duplicateDestinationFiles: { name: string; error: string }[] = [];
+      for (const file of filesToSync) {
+        const key = destinationKeyOf(file);
+        const firstRelativePath = seenDestinations.get(key);
+        if (firstRelativePath) {
+          duplicateDestinationPaths.add(file.relativePath);
+          duplicateDestinationFiles.push({
+            name: file.name,
+            error: `Skipped — another file ("${firstRelativePath}") also maps to the same destination (${key}); only the first is synced. Map these to different document types, or rename one, to sync both.`,
+          });
+        } else {
+          seenDestinations.set(key, file.relativePath);
+        }
+      }
+      if (duplicateDestinationPaths.size > 0) {
+        filesToSync = filesToSync.filter((f) => !duplicateDestinationPaths.has(f.relativePath));
+        logger.warn(
+          `${duplicateDestinationFiles.length} file(s) skipped — duplicate destination after docType mapping`
+        );
+      }
 
       logger.info(
         `Syncing ${filesToSync.length} files from SharePoint to MinIO (user skipped: ${
           skipFiles?.length || 0
-        }, identical: ${identicalFiles.length})`
+        }, identical: ${identicalFiles.length}, duplicate destination: ${duplicateDestinationFiles.length})`
       );
 
       const syncResults = {
@@ -328,7 +400,9 @@ export class SharePointController {
         syncedFiles: [] as string[],
         skippedFiles: [...(skipFiles || []), ...identicalFiles],
         identicalFiles,
-        failedFiles: [] as { name: string; error: string }[],
+        failedFiles: [...duplicateDestinationFiles] as { name: string; error: string }[],
+        truncated,
+        skippedFolders,
       };
 
       // Sync each file
@@ -337,8 +411,10 @@ export class SharePointController {
           // Download file from SharePoint
           const fileBuffer = await this.sharePointService.downloadFile(siteUrl, file.serverRelativeUrl, auth);
 
-          // Use docType from file (subfolder name) or fallback to request docType
-          const targetDocType = file.docType || docType || '';
+          // Manually-assigned type (from the review dialog's per-row
+          // selector) wins over auto-detection from the parent folder name,
+          // which in turn wins over the request-level fallback docType.
+          const targetDocType = docTypeOverrides?.[file.relativePath] || file.docType || docType || '';
 
           logger.info(
             `File: ${file.name}, docType from file: ${file.docType}, final docType: ${targetDocType}`

--- a/src/helpers/auth/attachSessionIfPresent.ts
+++ b/src/helpers/auth/attachSessionIfPresent.ts
@@ -1,0 +1,35 @@
+// Unlike requireSession, this never blocks a request — it populates
+// req.spSession/req.spSessionRawToken when a valid session exists and
+// calls next() either way. Deliberately non-blocking: the SharePoint
+// routes are dual-purpose, and on-prem NTLM requests never have a session
+// at all. SharePointController.resolveAuth is what actually requires one,
+// per-request, when the target siteUrl is Online.
+import { Response, NextFunction } from 'express';
+import { resolveSession } from '../../services/auth/SessionService';
+import { parseCookieHeader, sessionCookieName } from '../../util/cookies';
+
+const BEARER_PREFIX = 'Bearer ';
+
+function extractRawToken(req: any): string | null {
+  const authHeader = req.headers?.authorization;
+  if (typeof authHeader === 'string' && authHeader.startsWith(BEARER_PREFIX)) {
+    return authHeader.slice(BEARER_PREFIX.length).trim();
+  }
+  const cookies = parseCookieHeader(req.headers?.cookie);
+  return cookies[sessionCookieName] || null;
+}
+
+export async function attachSessionIfPresent(req: any, _res: Response, next: NextFunction): Promise<void> {
+  const rawToken = extractRawToken(req);
+  if (!rawToken) {
+    next();
+    return;
+  }
+
+  const session = await resolveSession(rawToken);
+  if (session) {
+    req.spSession = session;
+    req.spSessionRawToken = rawToken;
+  }
+  next();
+}

--- a/src/helpers/auth/requireCsrf.ts
+++ b/src/helpers/auth/requireCsrf.ts
@@ -1,0 +1,59 @@
+// CSRF protection for state-changing SharePoint-session routes. Mandatory
+// for the cookie transport, since that session cookie is SameSite=None
+// (required for the OAuth callback + ADO-iframe context) and so gets zero
+// CSRF protection from SameSite alone — replaced here with a strict-Origin
+// allowlist plus a double-submit token compare. Skipped for bearer
+// transport (no ambient credential a cross-site request could ride) and
+// for no session at all (on-prem NTLM routes, which never carry
+// req.spSession) — nothing to protect in either case.
+//
+// Must run AFTER attachSessionIfPresent/requireSession.
+import { Response, NextFunction } from 'express';
+import { verifyCsrf } from '../../services/auth/SessionService';
+import { getAllowedOrigins } from '../../util/authConfig';
+
+const CSRF_HEADER = 'x-csrf-token';
+
+export async function requireCsrf(req: any, res: Response, next: NextFunction): Promise<void> {
+  if (!req.spSession) {
+    next();
+    return;
+  }
+
+  const origin = req.headers?.origin;
+  if (!origin) {
+    res.status(403).json({ success: false, error: 'csrf_origin_missing' });
+    return;
+  }
+
+  let allowedOrigins: string[];
+  try {
+    allowedOrigins = getAllowedOrigins();
+  } catch {
+    allowedOrigins = [];
+  }
+  if (!allowedOrigins.includes(origin)) {
+    res.status(403).json({ success: false, error: 'csrf_origin_not_allowed' });
+    return;
+  }
+
+  if (req.spSession?.transport === 'bearer') {
+    next();
+    return;
+  }
+
+  const csrfToken = req.headers?.[CSRF_HEADER];
+  if (typeof csrfToken !== 'string' || !csrfToken) {
+    res.status(403).json({ success: false, error: 'csrf_token_missing' });
+    return;
+  }
+
+  const rawSessionToken = req.spSessionRawToken;
+  const valid = rawSessionToken ? await verifyCsrf(rawSessionToken, csrfToken) : false;
+  if (!valid) {
+    res.status(403).json({ success: false, error: 'csrf_token_invalid' });
+    return;
+  }
+
+  next();
+}

--- a/src/helpers/auth/requireSession.ts
+++ b/src/helpers/auth/requireSession.ts
@@ -1,0 +1,37 @@
+// Session-resolution middleware. Tries the Authorization: Bearer header
+// first (ADO-embedded transport), then the __Host- session cookie
+// (standalone transport) — either missing or no longer live gets a
+// machine-readable 401 the frontend reacts to by reopening the sign-in
+// popup, never a silent retry.
+import { Response, NextFunction } from 'express';
+import { resolveSession } from '../../services/auth/SessionService';
+import { parseCookieHeader, sessionCookieName } from '../../util/cookies';
+
+const BEARER_PREFIX = 'Bearer ';
+
+function extractRawToken(req: any): string | null {
+  const authHeader = req.headers?.authorization;
+  if (typeof authHeader === 'string' && authHeader.startsWith(BEARER_PREFIX)) {
+    return authHeader.slice(BEARER_PREFIX.length).trim();
+  }
+  const cookies = parseCookieHeader(req.headers?.cookie);
+  return cookies[sessionCookieName] || null;
+}
+
+export async function requireSession(req: any, res: Response, next: NextFunction): Promise<void> {
+  const rawToken = extractRawToken(req);
+  if (!rawToken) {
+    res.status(401).json({ success: false, error: 'reauth_required' });
+    return;
+  }
+
+  const session = await resolveSession(rawToken);
+  if (!session) {
+    res.status(401).json({ success: false, error: 'reauth_required' });
+    return;
+  }
+
+  req.spSession = session;
+  req.spSessionRawToken = rawToken; // needed by requireCsrf's double-submit compare
+  next();
+}

--- a/src/models/AuthSession.ts
+++ b/src/models/AuthSession.ts
@@ -1,0 +1,42 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+// The session record both transports (cookie and bearer-handle) resolve
+// to. Only the SHA-256 hash of the session token is ever stored — a
+// database dump yields no usable credential, matching SessionHandleCode's
+// and OAuthTransaction's posture on `state`.
+export interface IAuthSession extends Document {
+  sessionTokenHash: string;
+  homeAccountId: string; // MSAL cache partition key — see MsalTokenCache
+  transport: 'cookie' | 'bearer';
+  csrfTokenHash: string;
+  displayName?: string; // from the ID token — this is why User.Read is not requested
+  userPrincipalName?: string;
+  tenantId?: string;
+  lastSeenAt: Date; // slid on each authorized request, drives idle expiry
+  idleExpiresAt: Date; // rolling window
+  absoluteExpiresAt: Date; // hard cap regardless of activity; TTL index
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const AuthSessionSchema = new Schema(
+  {
+    sessionTokenHash: { type: String, required: true, unique: true },
+    homeAccountId: { type: String, required: true },
+    transport: { type: String, required: true, enum: ['cookie', 'bearer'] },
+    csrfTokenHash: { type: String, required: true },
+    displayName: { type: String, required: false },
+    userPrincipalName: { type: String, required: false },
+    tenantId: { type: String, required: false },
+    lastSeenAt: { type: Date, required: true, default: Date.now },
+    idleExpiresAt: { type: Date, required: true },
+    absoluteExpiresAt: { type: Date, required: true, expires: 0 },
+  },
+  { timestamps: true }
+);
+
+AuthSessionSchema.index({ sessionTokenHash: 1 }, { unique: true });
+AuthSessionSchema.index({ homeAccountId: 1 });
+AuthSessionSchema.index({ absoluteExpiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const AuthSession = mongoose.model<IAuthSession>('AuthSession', AuthSessionSchema);

--- a/src/models/MsalTokenCache.ts
+++ b/src/models/MsalTokenCache.ts
@@ -1,0 +1,33 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+// The homeAccountId-partitioned, AES-256-GCM-encrypted MSAL token cache
+// (see tokenCacheCipher.ts + MongoTokenCachePlugin.ts). One document per
+// signed-in user; MSAL's own cache serialization format lives inside
+// `ciphertext`, never in plaintext at rest.
+export interface IMsalTokenCache extends Document {
+  homeAccountId: string;
+  ciphertext: string; // base64
+  iv: string; // base64
+  authTag: string; // base64
+  keyVersion: number; // enables key rotation without orphaning existing rows
+  expiresAt: Date; // rolling ~90-day TTL, matching Entra's refresh-token inactivity window
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const MsalTokenCacheSchema = new Schema(
+  {
+    homeAccountId: { type: String, required: true, unique: true },
+    ciphertext: { type: String, required: true },
+    iv: { type: String, required: true },
+    authTag: { type: String, required: true },
+    keyVersion: { type: Number, required: true, default: 1 },
+    expiresAt: { type: Date, required: true, expires: 0 },
+  },
+  { timestamps: true }
+);
+
+MsalTokenCacheSchema.index({ homeAccountId: 1 }, { unique: true });
+MsalTokenCacheSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const MsalTokenCache = mongoose.model<IMsalTokenCache>('MsalTokenCache', MsalTokenCacheSchema);

--- a/src/models/OAuthTransaction.ts
+++ b/src/models/OAuthTransaction.ts
@@ -1,0 +1,36 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+// The short-lived PKCE/state record created at GET /auth/login and consumed
+// exactly once at GET /auth/callback via findOneAndDelete — that atomicity
+// is what makes state replay structurally impossible rather than merely
+// check-then-delete racy. See OAuthTransactionService.
+export interface IOAuthTransaction extends Document {
+  state: string; // opaque random value returned by Entra on the callback; matched, never a bearer credential itself
+  codeVerifier: string; // PKCE code_verifier, kept server-side only
+  nonce: string; // validated against the ID token's nonce claim at callback
+  openerOrigin: string; // validated against the CORS allowlist at /auth/login time; never reflected unvalidated into the callback page
+  transport: 'cookie' | 'bearer';
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const OAuthTransactionSchema = new Schema(
+  {
+    state: { type: String, required: true, unique: true },
+    codeVerifier: { type: String, required: true },
+    nonce: { type: String, required: true },
+    openerOrigin: { type: String, required: true },
+    transport: { type: String, required: true, enum: ['cookie', 'bearer'] },
+    // TTL index: Mongo's background reaper runs on a ~60s cycle and is a
+    // garbage collector only — consumeTransaction() always re-checks
+    // expiresAt in its own query predicate rather than trusting the reaper
+    // to have removed an expired-but-still-physically-present row.
+    expiresAt: { type: Date, required: true, expires: 0 },
+  },
+  { timestamps: true }
+);
+
+OAuthTransactionSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const OAuthTransaction = mongoose.model<IOAuthTransaction>('OAuthTransaction', OAuthTransactionSchema);

--- a/src/models/SessionHandleCode.ts
+++ b/src/models/SessionHandleCode.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+// The one-time code that crosses postMessage from the auth popup back to
+// the ADO-embedded iframe app (bearer-transport only). A separate model
+// from OAuthTransaction so their very different TTLs (~10min pre-auth vs.
+// ~60s post-auth) stay independent.
+//
+// AuthSession stores only a session token's hash, never the raw value, so
+// a handle code can't merely reference a session by ID — it carries the
+// raw token itself, encrypted at rest (AES-256-GCM via tokenCacheCipher,
+// reused here as a generic string cipher). Consumed exactly once via
+// findOneAndDelete at POST /auth/session/exchange; after that the raw token
+// exists only in the caller's memory, never storage (see authTransport.js).
+export interface ISessionHandleCode extends Document {
+  codeHash: string;
+  sessionTokenCiphertext: string; // base64
+  sessionTokenIv: string; // base64
+  sessionTokenAuthTag: string; // base64
+  sessionTokenKeyVersion: number;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const SessionHandleCodeSchema = new Schema(
+  {
+    codeHash: { type: String, required: true, unique: true },
+    sessionTokenCiphertext: { type: String, required: true },
+    sessionTokenIv: { type: String, required: true },
+    sessionTokenAuthTag: { type: String, required: true },
+    sessionTokenKeyVersion: { type: Number, required: true, default: 1 },
+    expiresAt: { type: Date, required: true, expires: 0 },
+  },
+  { timestamps: true }
+);
+
+SessionHandleCodeSchema.index({ codeHash: 1 }, { unique: true });
+SessionHandleCodeSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const SessionHandleCode = mongoose.model<ISessionHandleCode>('SessionHandleCode', SessionHandleCodeSchema);

--- a/src/models/SharePointConfig.ts
+++ b/src/models/SharePointConfig.ts
@@ -7,8 +7,8 @@ export interface ISharePointConfig extends Document {
   userId?: string; // Optional: per-user configuration
   projectName?: string; // Optional: per-project configuration
   siteUrl: string; // Full SharePoint site URL
-  library: string; // Document library name
-  folder: string; // Folder path within library
+  library?: string; // Document library name — on-prem only; blank for Online configs and paste-a-URL on-prem configs
+  folder?: string; // Folder path within library — blank for Online configs (the whole location is siteUrl)
   displayName?: string; // Friendly name for UI
   lastUsed?: Date; // Track when last used
   createdAt: Date;
@@ -22,8 +22,14 @@ const SharePointConfigSchema = new Schema(
     userId: { type: String, required: false },
     projectName: { type: String, required: false },
     siteUrl: { type: String, required: true },
-    library: { type: String, required: true, default: 'Shared Documents' },
-    folder: { type: String, required: true, default: 'Templates' },
+    // Not required: an Online config's siteUrl is itself the pasted
+    // sharing/folder link, and even on-prem paste-a-URL configs
+    // (resolveSiteFromUrl) leave library blank. Mongoose's built-in
+    // `required` validator on a String path rejects an explicit empty
+    // string as "missing", so these must stay optional rather than
+    // required-with-a-default — a default only ever fills in `undefined`.
+    library: { type: String, required: false },
+    folder: { type: String, required: false },
     displayName: { type: String, required: false },
     lastUsed: { type: Date, default: Date.now },
   },

--- a/src/models/SharePointConfig.ts
+++ b/src/models/SharePointConfig.ts
@@ -11,6 +11,11 @@ export interface ISharePointConfig extends Document {
   folder?: string; // Folder path within library — blank for Online configs (the whole location is siteUrl)
   displayName?: string; // Friendly name for UI
   lastUsed?: Date; // Track when last used
+  // Relink-migration discriminator (see SharePointController.getConfig and
+  // sharePointLinkClassifier.ts) — optional, so pre-existing rows stay valid.
+  authType?: 'onprem' | 'online';
+  requiresRelink?: boolean; // sticky: set once a saved Online link is proven unresolvable via /shares
+  linkResolvedAt?: Date; // last successful resolution — the "confirmed" marker
   createdAt: Date;
   updatedAt: Date;
 }
@@ -32,6 +37,9 @@ const SharePointConfigSchema = new Schema(
     folder: { type: String, required: false },
     displayName: { type: String, required: false },
     lastUsed: { type: Date, default: Date.now },
+    authType: { type: String, required: false, enum: ['onprem', 'online'] },
+    requiresRelink: { type: Boolean, required: false, default: false },
+    linkResolvedAt: { type: Date, required: false },
   },
   {
     timestamps: true,

--- a/src/models/SharePointResolvedRoot.ts
+++ b/src/models/SharePointResolvedRoot.ts
@@ -1,0 +1,42 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+// Designed to bind a resolved {driveId, itemId} to the session that
+// resolved it, so Files.Read.All's effective blast radius stays limited to
+// libraries the user explicitly linked, not everything the scope could
+// technically reach. NOT currently wired into any controller/service —
+// GraphSharePointService re-resolves the pasted URL fresh on every call
+// instead, so no code path accepts a client-supplied driveId/itemId today.
+// This model is unused; keep or wire it in deliberately, don't assume it's
+// an active control.
+export interface ISharePointResolvedRoot extends Document {
+  homeAccountId: string;
+  shareUrlHash: string; // hash, not the raw URL — a "Copy Link" URL carries a capability token
+  driveId: string;
+  itemId: string;
+  name?: string;
+  resolvedAt: Date;
+  expiresAt: Date; // 24h TTL — re-resolved on next use past that, cheap since it's one Graph call
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const SharePointResolvedRootSchema = new Schema(
+  {
+    homeAccountId: { type: String, required: true },
+    shareUrlHash: { type: String, required: true },
+    driveId: { type: String, required: true },
+    itemId: { type: String, required: true },
+    name: { type: String, required: false },
+    resolvedAt: { type: Date, required: true, default: Date.now },
+    expiresAt: { type: Date, required: true, expires: 0 },
+  },
+  { timestamps: true }
+);
+
+SharePointResolvedRootSchema.index({ homeAccountId: 1, shareUrlHash: 1 }, { unique: true });
+SharePointResolvedRootSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const SharePointResolvedRoot = mongoose.model<ISharePointResolvedRoot>(
+  'SharePointResolvedRoot',
+  SharePointResolvedRootSchema
+);

--- a/src/routes/JsonDocRoutes.ts
+++ b/src/routes/JsonDocRoutes.ts
@@ -598,6 +598,9 @@ export class Routes {
       .route('/azure/user/profile')
       .get((req: Request, res: Response) => this.dataProviderController.getUserProfile(req, res));
     app
+      .route('/azure/user/windows-identity')
+      .get((req: Request, res: Response) => this.dataProviderController.getWindowsIdentity(req, res));
+    app
       .route('/azure/link-types')
       .get((req: Request, res: Response) => this.dataProviderController.getCollectionLinkTypes(req, res));
 
@@ -708,7 +711,12 @@ export class Routes {
       .route('/sharepoint/configs/all')
       .get((req: Request, res: Response) => this.sharePointController.getAllConfigs(req, res));
 
-    // Note: OAuth is now handled by frontend (SPA flow with PKCE)
-    // Backend only provides SharePoint REST API access with OAuth tokens from frontend
+    app
+      .route('/sharepoint/resolve-url')
+      .post((req: Request, res: Response) => this.sharePointController.resolveUrl(req, res));
+
+    // Note: for SharePoint Online, the frontend sends a Microsoft Graph access
+    // token the user pastes in (e.g. from Graph Explorer) — no Azure AD app
+    // registration or OAuth popup involved.
   }
 }

--- a/src/routes/JsonDocRoutes.ts
+++ b/src/routes/JsonDocRoutes.ts
@@ -9,6 +9,10 @@ import moment from 'moment';
 import { DatabaseController } from '../controllers/DatabaseController';
 import { DataProviderController } from '../controllers/DataProviderController';
 import { SharePointController } from '../controllers/SharePointController';
+import { AuthController } from '../controllers/AuthController';
+import { requireSession } from '../helpers/auth/requireSession';
+import { requireCsrf } from '../helpers/auth/requireCsrf';
+import { attachSessionIfPresent } from '../helpers/auth/attachSessionIfPresent';
 const Minio = require('minio');
 
 export class Routes {
@@ -17,6 +21,7 @@ export class Routes {
   public dataBaseController: DatabaseController = new DatabaseController();
   public dataProviderController: DataProviderController = new DataProviderController();
   public sharePointController: SharePointController = new SharePointController();
+  public authController: AuthController = new AuthController();
 
   public routes(app: any, upload: any): void {
     app.route('/health').get(async (_req: Request, res: Response) => {
@@ -432,6 +437,9 @@ export class Routes {
           const statusCode = Number(err?.statusCode || 500);
           res.status(statusCode >= 400 && statusCode < 600 ? statusCode : 500).json({
             message: `Failed to create the document ${err?.message || err}`,
+            code: err?.code,
+            dependency: err?.dependency,
+            url: err?.url,
             //Error not structured correctly
             error: err,
           });
@@ -543,7 +551,13 @@ export class Routes {
           // downloadFile streams the response directly
         })
         .catch((err) => {
-          res.status(404).json({ status: 404, message: err });
+          const statusCode = Number(err?.statusCode) || 404;
+          res.status(statusCode).json({
+            status: statusCode,
+            message: err?.message || String(err),
+            code: err?.code,
+            dependency: err?.dependency,
+          });
         });
     });
     app.route('/minio/createBucket').post(async (req: Request, res: Response) => {
@@ -680,22 +694,27 @@ export class Routes {
       .route('/azure/work-item-types')
       .get((req: Request, res: Response) => this.dataProviderController.getWorkItemTypeList(req, res));
 
-    // SharePoint integration routes
+    // SharePoint integration routes. attachSessionIfPresent/requireCsrf are
+    // both no-ops when there's no session — these routes are dual-purpose
+    // and on-prem NTLM never has one. For an Online siteUrl,
+    // SharePointController.resolveAuth requires the session and requireCsrf
+    // enforces the double-submit check (the cookie is SameSite=None, so
+    // nothing else protects it — see requireCsrf.ts).
     app
       .route('/sharepoint/test-connection')
-      .post((req: Request, res: Response) => this.sharePointController.testConnection(req, res));
+      .post(attachSessionIfPresent, requireCsrf, (req: Request, res: Response) => this.sharePointController.testConnection(req, res));
 
     app
       .route('/sharepoint/list-files')
-      .post((req: Request, res: Response) => this.sharePointController.listFiles(req, res));
+      .post(attachSessionIfPresent, requireCsrf, (req: Request, res: Response) => this.sharePointController.listFiles(req, res));
 
     app
       .route('/sharepoint/check-conflicts')
-      .post((req: Request, res: Response) => this.sharePointController.checkConflicts(req, res));
+      .post(attachSessionIfPresent, requireCsrf, (req: Request, res: Response) => this.sharePointController.checkConflicts(req, res));
 
     app
       .route('/sharepoint/sync-templates')
-      .post((req: Request, res: Response) => this.sharePointController.syncTemplates(req, res));
+      .post(attachSessionIfPresent, requireCsrf, (req: Request, res: Response) => this.sharePointController.syncTemplates(req, res));
 
     app
       .route('/sharepoint/config')
@@ -715,8 +734,17 @@ export class Routes {
       .route('/sharepoint/resolve-url')
       .post((req: Request, res: Response) => this.sharePointController.resolveUrl(req, res));
 
-    // Note: for SharePoint Online, the frontend sends a Microsoft Graph access
-    // token the user pastes in (e.g. from Graph Explorer) — no Azure AD app
-    // registration or OAuth popup involved.
+    // SharePoint Online OAuth (BFF) — Authorization Code + PKCE, popup-based.
+    // SharePoint Online authenticates exclusively through this flow; a
+    // client-supplied Graph token is rejected (see resolveAuth).
+    app.route('/auth/login').get((req: Request, res: Response) => this.authController.login(req, res));
+    app.route('/auth/callback').get((req: Request, res: Response) => this.authController.callback(req, res));
+    app.route('/auth/session/exchange').post((req: Request, res: Response) => this.authController.exchangeSessionHandle(req, res));
+    app
+      .route('/auth/session')
+      .get(requireSession, (req: Request, res: Response) => this.authController.getSessionInfo(req, res));
+    app
+      .route('/auth/logout')
+      .post(requireSession, requireCsrf, (req: Request, res: Response) => this.authController.logout(req, res));
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,10 +3,15 @@ dotenv.config();
 import App from './app';
 import logger from './util/logger';
 import connectToDatabase from './util/mongodb';
+import { assertAuthConfig } from './util/authConfig';
 
 const app = new App().app;
 const startServer = async () => {
   try {
+    // Fail fast on a misconfigured OAuth/session env (missing CLIENT_SECRET,
+    // http:// REDIRECT_URI, wildcard CORS_ALLOWED_ORIGINS, etc.) before
+    // accepting any traffic.
+    assertAuthConfig();
     await connectToDatabase();
     app.listen(process.env.PORT || 3000, () => {
       logger.info(`dg-api-gate listening on port ${process.env.PORT || 3000}`);

--- a/src/services/GraphSharePointService.ts
+++ b/src/services/GraphSharePointService.ts
@@ -1,9 +1,34 @@
 import axios from 'axios';
 import logger from '../util/logger';
-import { SharePointFile, SharePointOAuthToken } from './SharePointService';
+import {
+  SharePointFile,
+  SharePointFileListing,
+  SharePointOAuthToken,
+  SkippedFolder,
+  MAX_RECURSION_DEPTH,
+  MAX_RECURSION_FILES,
+  MAX_SKIPPED_FOLDERS_RECORDED,
+  CONCURRENT_FOLDER_FETCHES,
+} from './SharePointService';
+import { withThrottleRetry, createRetryBudget, RetryBudget, RETRYABLE_STATUSES, REQUEST_TIMEOUT_MS } from './sharePointRetry';
 import { isTemplateFileName, isWithinMaxTemplateSize } from './sharePointFileValidation';
 
 const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+
+// One BFS queue entry — a folder's "list children" URL still to walk.
+// `relativePath` is that folder's own path relative to the shared root
+// ('' at the root itself); `parentName` is undefined only at the root, so
+// files found there correctly get no docType.
+type GraphFolderQueueItem = { childrenUrl: string; relativePath: string; depth: number; parentName?: string };
+
+// Result of fetching one folder's children. `files` is populated even when
+// `skipped` is also set — mirrors SharePointService's FetchFolderResult.
+interface GraphFetchFolderResult {
+  files: SharePointFile[];
+  subfoldersToEnqueue: GraphFolderQueueItem[];
+  skipped?: { relativePath: string; reason: string };
+  depthCapped?: boolean;
+}
 
 // Hostnames a pasted "share this" link is allowed to point at. Without this,
 // pasting a non-Microsoft URL into the Online tab fails deep inside the
@@ -106,25 +131,46 @@ export class GraphSharePointService {
     return error;
   }
 
-  private async get(url: string, accessToken: string): Promise<any> {
-    try {
-      return await axios.get(url, {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          // Documented specifically for /shares/...: without it, Graph may
-          // refuse to fully resolve a sharing link the caller hasn't
-          // "redeemed" before (equivalent to a user never having opened the
-          // link in a browser under this identity), surfacing as a 403 even
-          // with a token that holds sufficient Files.Read.All/Sites.Read.All
-          // scope. "IfNecessary" only grants access for this request's
-          // duration, matching what a read-only template sync needs. Sent
-          // on every call, not just /shares — Prefer is advisory HTTP, and
-          // the /sites and /drives endpoints this service also calls simply
-          // ignore a Prefer value they don't recognize.
-          Prefer: 'redeemSharingLinkIfNecessary',
-        },
-      });
-    } catch (error: any) {
+  /**
+   * `retryBudget`, when passed, is shared across every request in one
+   * `listTemplateFiles` walk — see sharePointRetry.ts's doc comment for why
+   * that matters once folder fetches run concurrently. Callers that don't
+   * pass one (testShareAccess, resolveFolderByPath's candidate-path walk,
+   * etc.) still get up to 2 retries per call, just not budget-capped across
+   * calls — acceptable since only genuine 429/503 responses are retryable,
+   * never the 404s that walk expects from a wrong candidate.
+   */
+  private async get(url: string, accessToken: string, retryBudget?: RetryBudget): Promise<any> {
+    return withThrottleRetry(
+      () =>
+        axios.get(url, {
+          timeout: REQUEST_TIMEOUT_MS,
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            // Documented specifically for /shares/...: without it, Graph may
+            // refuse to fully resolve a sharing link the caller hasn't
+            // "redeemed" before (equivalent to a user never having opened the
+            // link in a browser under this identity), surfacing as a 403 even
+            // with a token that holds sufficient Files.Read.All/Sites.Read.All
+            // scope. "IfNecessary" only grants access for this request's
+            // duration, matching what a read-only template sync needs. Sent
+            // on every call, not just /shares — Prefer is advisory HTTP, and
+            // the /sites and /drives endpoints this service also calls simply
+            // ignore a Prefer value they don't recognize.
+            Prefer: 'redeemSharingLinkIfNecessary',
+          },
+        }),
+      (outcome) => {
+        const status = outcome.error?.response?.status;
+        return {
+          retryable: RETRYABLE_STATUSES.includes(status),
+          // Read Retry-After BEFORE errorForStatus() maps the error below —
+          // that mapping discards the original response/headers entirely.
+          retryAfter: outcome.error?.response?.headers?.['retry-after'],
+        };
+      },
+      { budget: retryBudget, label: url }
+    ).catch((error: any) => {
       if (error.response) {
         // Never log the token; the URL itself carries no secret (Graph
         // resource paths, not signed download URLs) so it's safe to log for
@@ -133,7 +179,7 @@ export class GraphSharePointService {
         throw this.errorForStatus(error.response.status);
       }
       throw new Error(`Could not reach Microsoft Graph: ${error.message}`);
-    }
+    });
   }
 
   private isPrivateHost(hostname: string): boolean {
@@ -264,11 +310,11 @@ export class GraphSharePointService {
    * Follows @odata.nextLink so libraries over the 200-item Graph page size
    * are still fully listed.
    */
-  private async listChildren(url: string, accessToken: string): Promise<any[]> {
+  private async listChildren(url: string, accessToken: string, retryBudget?: RetryBudget): Promise<any[]> {
     const items: any[] = [];
     let nextUrl: string | undefined = url;
     while (nextUrl) {
-      const response = await this.get(nextUrl, accessToken);
+      const response = await this.get(nextUrl, accessToken, retryBudget);
       items.push(...(response.data.value || []));
       nextUrl = response.data['@odata.nextLink'];
     }
@@ -276,65 +322,173 @@ export class GraphSharePointService {
   }
 
   /**
-   * Lists all Word template files one level below the shared folder's
-   * subfolders. Same docType convention as the on-prem path: each
-   * subfolder's name becomes the docType, and only .docx/.dotx files are
-   * returned. Emits the same SharePointFile shape the on-prem path uses —
-   * `serverRelativeUrl` carries Graph's pre-signed download URL instead of a
-   * server-relative path, which is exactly what downloadFile() expects back.
+   * Lists all Word template files under the shared folder, recursively —
+   * including files sitting directly in the shared folder itself (a flat
+   * folder, no per-doc-type subfolders) and files nested more than one
+   * level deep. Same docType convention as the on-prem path: a file's
+   * immediate parent folder name becomes its docType, undefined at the
+   * shared-folder root. Mirrors `SharePointService.listTemplateFiles`'s
+   * BFS walk and safety caps, built on `listChildren`'s existing
+   * `@odata.nextLink` pagination instead of the one-level `/Folders`+`/Files`
+   * pair the on-prem path uses. Emits the same SharePointFile shape the
+   * on-prem path uses — `serverRelativeUrl` carries Graph's pre-signed
+   * download URL instead of a server-relative path, which is exactly what
+   * downloadFile() expects back.
    */
-  async listTemplateFiles(shareUrl: string, token: SharePointOAuthToken): Promise<SharePointFile[]> {
+  async listTemplateFiles(shareUrl: string, token: SharePointOAuthToken): Promise<SharePointFileListing> {
     const rootChildrenUrl = await this.resolveRootChildrenUrl(shareUrl, token.accessToken);
-    const subfolders = await this.listChildren(rootChildrenUrl, token.accessToken);
+
+    const queue: GraphFolderQueueItem[] = [{ childrenUrl: rootChildrenUrl, relativePath: '', depth: 0 }];
 
     const allTemplateFiles: SharePointFile[] = [];
+    let truncated = false;
+    // Shared across every request this walk makes — see sharePointRetry.ts.
+    const retryBudget = createRetryBudget();
+    const skippedFolders: SkippedFolder[] = [];
+    let totalSkippedFolders = 0;
 
+    // Mirrors SharePointService.listTemplateFiles's recordSkippedFolder —
+    // `depth > 0` gates tolerance, a denied shared-folder root always
+    // aborts (see SharePointFileListing's doc comment).
+    const recordSkippedFolder = (relPath: string, reason: string) => {
+      totalSkippedFolders += 1;
+      if (skippedFolders.length < MAX_SKIPPED_FOLDERS_RECORDED) {
+        skippedFolders.push({ relativePath: relPath, reason });
+      }
+    };
+
+    // Batch fetches (I/O only), accumulate strictly in queue order — see
+    // SharePointService.listTemplateFiles's identical comment for why this
+    // keeps output deterministic under concurrency.
+    while (queue.length > 0 && !truncated) {
+      const batch = queue.splice(0, CONCURRENT_FOLDER_FETCHES);
+      const results = await Promise.all(batch.map((item) => this.fetchFolder(token, item, retryBudget)));
+
+      for (const result of results) {
+        if (truncated) break;
+
+        for (const file of result.files) {
+          if (allTemplateFiles.length >= MAX_RECURSION_FILES) {
+            truncated = true;
+            break;
+          }
+          allTemplateFiles.push(file);
+        }
+        if (truncated) break;
+
+        if (result.skipped) {
+          recordSkippedFolder(result.skipped.relativePath, result.skipped.reason);
+          continue;
+        }
+        if (result.depthCapped) {
+          truncated = true;
+          continue;
+        }
+        queue.push(...result.subfoldersToEnqueue);
+      }
+    }
+
+    if (totalSkippedFolders > skippedFolders.length) {
+      skippedFolders.push({
+        relativePath: '',
+        reason: `…and ${totalSkippedFolders - skippedFolders.length} more folder(s) were also skipped`,
+      });
+    }
+
+    logger.info(
+      `Total template files found via Graph: ${allTemplateFiles.length}${truncated ? ' (truncated)' : ''}${
+        totalSkippedFolders ? `, ${totalSkippedFolders} folder(s) skipped (access denied)` : ''
+      }`
+    );
+
+    return { files: allTemplateFiles, truncated, skippedFolders };
+  }
+
+  /**
+   * Fetches one folder's children — the I/O unit `listTemplateFiles` runs
+   * CONCURRENT_FOLDER_FETCHES of at a time. Pure I/O, mirrors
+   * SharePointService.fetchFolder: no shared state is read or written
+   * here, so concurrent fetching can't change which files end up in the
+   * result or where the truncation cutoff falls (both are resolved by the
+   * caller, in queue order, once every promise in a batch has settled).
+   */
+  private async fetchFolder(
+    token: SharePointOAuthToken,
+    item: GraphFolderQueueItem,
+    retryBudget: RetryBudget
+  ): Promise<GraphFetchFolderResult> {
+    const { childrenUrl, relativePath, depth, parentName } = item;
+
+    let children: any[];
+    try {
+      children = await this.listChildren(childrenUrl, token.accessToken, retryBudget);
+    } catch (err: any) {
+      if (err.status === 403 && depth > 0) {
+        logger.warn(`Skipping inaccessible folder "${relativePath}" (Graph): ${err.message}`);
+        return { files: [], subfoldersToEnqueue: [], skipped: { relativePath, reason: err.message } };
+      }
+      throw err;
+    }
+
+    const templateFiles = children.filter((file: any) => {
+      if (file.folder) return false;
+      if (!isTemplateFileName(file.name)) return false;
+      if (!isWithinMaxTemplateSize(Number(file.size))) {
+        logger.warn(`Skipping SharePoint file "${file.name}" — size ${file.size} bytes exceeds the sync limit`);
+        return false;
+      }
+      return true;
+    });
+
+    const files: SharePointFile[] = [];
+    for (const file of templateFiles) {
+      const downloadUrl = file['@microsoft.graph.downloadUrl'];
+      if (!downloadUrl) {
+        logger.warn(`Skipping SharePoint file "${file.name}" — Graph did not return a download URL`);
+        continue;
+      }
+      files.push({
+        name: file.name,
+        serverRelativeUrl: downloadUrl,
+        timeCreated: file.createdDateTime,
+        timeLastModified: file.lastModifiedDateTime,
+        length: file.size,
+        docType: parentName,
+        relativePath: relativePath ? `${relativePath}/${file.name}` : file.name,
+      });
+    }
+
+    logger.info(`Found ${templateFiles.length} template files in "${relativePath || '(root)'}" (Graph)`);
+
+    const subfolders = children.filter((c: any) => c.folder && !c.name.startsWith('_') && !c.name.startsWith('.'));
+
+    if (depth >= MAX_RECURSION_DEPTH) {
+      if (subfolders.length > 0) {
+        logger.warn(
+          `Hit max recursion depth (${MAX_RECURSION_DEPTH}) at "${relativePath}" with ${subfolders.length} unexplored subfolder(s) (Graph)`
+        );
+        return { files, subfoldersToEnqueue: [], depthCapped: true };
+      }
+      return { files, subfoldersToEnqueue: [] };
+    }
+
+    const subfoldersToEnqueue: GraphFolderQueueItem[] = [];
     for (const subfolder of subfolders) {
-      if (!subfolder.folder) continue; // only folders are docType buckets
-
       const subfolderName = subfolder.name;
-      if (subfolderName.startsWith('_') || subfolderName.startsWith('.')) continue;
-
       const driveId = subfolder.parentReference?.driveId;
       const itemId = subfolder.id;
       if (!driveId || !itemId) {
         logger.warn(`Skipping SharePoint subfolder "${subfolderName}" — missing driveId/itemId in Graph response`);
         continue;
       }
-
-      const children = await this.listChildren(`${GRAPH_BASE_URL}/drives/${driveId}/items/${itemId}/children`, token.accessToken);
-
-      const templateFiles = children.filter((file: any) => {
-        if (file.folder) return false;
-        if (!isTemplateFileName(file.name)) return false;
-        if (!isWithinMaxTemplateSize(Number(file.size))) {
-          logger.warn(`Skipping SharePoint file "${file.name}" — size ${file.size} bytes exceeds the sync limit`);
-          return false;
-        }
-        return true;
+      subfoldersToEnqueue.push({
+        childrenUrl: `${GRAPH_BASE_URL}/drives/${driveId}/items/${itemId}/children`,
+        relativePath: relativePath ? `${relativePath}/${subfolderName}` : subfolderName,
+        depth: depth + 1,
+        parentName: subfolderName,
       });
-
-      for (const file of templateFiles) {
-        const downloadUrl = file['@microsoft.graph.downloadUrl'];
-        if (!downloadUrl) {
-          logger.warn(`Skipping SharePoint file "${file.name}" — Graph did not return a download URL`);
-          continue;
-        }
-        allTemplateFiles.push({
-          name: file.name,
-          serverRelativeUrl: downloadUrl,
-          timeCreated: file.createdDateTime,
-          timeLastModified: file.lastModifiedDateTime,
-          length: file.size,
-          docType: subfolderName,
-        });
-      }
-
-      logger.info(`Found ${templateFiles.length} template files in "${subfolderName}" (Graph)`);
     }
 
-    logger.info(`Total template files found via Graph: ${allTemplateFiles.length}`);
-
-    return allTemplateFiles;
+    return { files, subfoldersToEnqueue };
   }
 }

--- a/src/services/GraphSharePointService.ts
+++ b/src/services/GraphSharePointService.ts
@@ -1,0 +1,340 @@
+import axios from 'axios';
+import logger from '../util/logger';
+import { SharePointFile, SharePointOAuthToken } from './SharePointService';
+import { isTemplateFileName, isWithinMaxTemplateSize } from './sharePointFileValidation';
+
+const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+
+// Hostnames a pasted "share this" link is allowed to point at. Without this,
+// pasting a non-Microsoft URL into the Online tab fails deep inside the
+// /shares/{id}/driveItem Graph call with a confusing Graph error instead of
+// a clear one up front. Matches the allowlist a sibling project's production
+// Graph-ingestion implementation uses for this same pattern.
+const ALLOWED_SHARE_HOST_SUFFIXES = ['sharepoint.com', 'onedrive.com', 'sharepoint.us', 'onedrive.live.com'];
+
+function isMicrosoftSharingUrl(url: string): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (hostname.includes('1drv.ms')) return true;
+  return ALLOWED_SHARE_HOST_SUFFIXES.some((suffix) => hostname === suffix || hostname.endsWith(`.${suffix}`));
+}
+
+/**
+ * Two distinct URL shapes reach this code in practice:
+ *
+ *  1. A "Copy Link" sharing URL (what SharePoint's Share dialog issues),
+ *     e.g. https://tenant.sharepoint.com/:f:/r/teams/x/Shared Documents/y?d=<id>&...
+ *     Graph's /shares endpoint is Microsoft's documented mechanism for
+ *     resolving exactly this kind of token-bearing sharing URL directly to
+ *     a driveItem.
+ *
+ *  2. A plain browsed-folder address-bar URL — what a user gets by
+ *     navigating into the folder and copying the URL, NOT clicking "Copy
+ *     Link". This is actually the far more common case in practice. Its
+ *     shape is a library view page (.../Forms/AllItems.aspx) with the real
+ *     folder identified by a `?...&id=<url-encoded-server-relative-path>`
+ *     query parameter that SharePoint's page script reads client-side —
+ *     Graph has no built-in understanding of this `id=` convention, and
+ *     resolving the *page* URL via /shares would likely resolve to the
+ *     library root or the page itself, not the nested folder — a silent
+ *     wrong-target risk, worse than an outright error.
+ *
+ * This distinguishes the two by checking for a path-shaped `id` query
+ * parameter, and returns the decoded server-relative folder path for shape
+ * 2 so callers can resolve it via site-path walking instead of /shares.
+ */
+function parseAllItemsFolderPath(url: string): { hostname: string; folderPath: string } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  const idParam = parsed.searchParams.get('id');
+  if (!idParam || !idParam.startsWith('/')) return null;
+  return { hostname: parsed.hostname, folderPath: decodeURIComponent(idParam) };
+}
+
+/**
+ * Reads a SharePoint/OneDrive folder from a user-pasted URL, using a bearer
+ * token supplied by the caller (e.g. pasted from Graph Explorer). Accepts
+ * two distinct URL shapes a user might actually paste — see
+ * parseAllItemsFolderPath's doc comment for why they need different
+ * resolution paths:
+ *  - a "Copy Link" sharing URL, resolved via Graph's /shares endpoint
+ *    (mirrors the pattern already proven in req2ado's graph_client.py)
+ *  - a plain browsed-folder address-bar URL, resolved by walking the
+ *    server-relative path to find its site, then addressing the remaining
+ *    path within that site's default drive
+ */
+export class GraphSharePointService {
+  /**
+   * Encodes a sharing URL into the opaque "shareId" Graph's /shares endpoint
+   * expects: "u!" + unpadded base64url(url). See:
+   * https://learn.microsoft.com/graph/api/shares-get
+   *
+   * Single choke point for both public methods below — validates the URL is
+   * actually a Microsoft SharePoint/OneDrive link *before* any network call,
+   * rather than letting a mispasted URL fail deep inside the Graph request.
+   */
+  private encodeShareId(url: string): string {
+    if (!isMicrosoftSharingUrl(url)) {
+      throw new Error(
+        'That doesn’t look like a SharePoint or OneDrive link — expected a sharepoint.com, onedrive.com, or 1drv.ms URL'
+      );
+    }
+    const base64 = Buffer.from(url, 'utf-8').toString('base64');
+    const urlSafe = base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    return `u!${urlSafe}`;
+  }
+
+  private errorForStatus(status: number): Error {
+    const messages: Record<number, string> = {
+      401: 'Graph access token expired or invalid — paste a fresh one',
+      403: 'This token does not have permission to read this SharePoint folder',
+      404: 'SharePoint folder not found for this sharing link',
+    };
+    // Carry the real status through so callers can respond 4xx (an expired
+    // token is an expected client-side condition, not a server error) rather
+    // than an unconditional 500.
+    const error: any = new Error(messages[status] || `Microsoft Graph error: ${status}`);
+    error.status = status >= 400 && status < 500 ? status : 502;
+    return error;
+  }
+
+  private async get(url: string, accessToken: string): Promise<any> {
+    try {
+      return await axios.get(url, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          // Documented specifically for /shares/...: without it, Graph may
+          // refuse to fully resolve a sharing link the caller hasn't
+          // "redeemed" before (equivalent to a user never having opened the
+          // link in a browser under this identity), surfacing as a 403 even
+          // with a token that holds sufficient Files.Read.All/Sites.Read.All
+          // scope. "IfNecessary" only grants access for this request's
+          // duration, matching what a read-only template sync needs. Sent
+          // on every call, not just /shares — Prefer is advisory HTTP, and
+          // the /sites and /drives endpoints this service also calls simply
+          // ignore a Prefer value they don't recognize.
+          Prefer: 'redeemSharingLinkIfNecessary',
+        },
+      });
+    } catch (error: any) {
+      if (error.response) {
+        // Never log the token; the URL itself carries no secret (Graph
+        // resource paths, not signed download URLs) so it's safe to log for
+        // diagnosing exactly which resolution step failed and why.
+        logger.warn(`Graph request failed (${error.response.status}): ${url}`);
+        throw this.errorForStatus(error.response.status);
+      }
+      throw new Error(`Could not reach Microsoft Graph: ${error.message}`);
+    }
+  }
+
+  private isPrivateHost(hostname: string): boolean {
+    return (
+      hostname === 'localhost' ||
+      /^127\./.test(hostname) ||
+      /^10\./.test(hostname) ||
+      /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname) ||
+      /^192\.168\./.test(hostname) ||
+      /^169\.254\./.test(hostname)
+    );
+  }
+
+  /**
+   * Resolves a browsed folder's server-relative path (extracted from an
+   * AllItems.aspx `id=` query param) to a folder driveItem, without ever
+   * assuming where the site boundary sits within that path — Graph's
+   * `/sites/{hostname}:/{path}` 404s unless `{path}` is exactly a site's own
+   * path (no "nearest site" resolution the way on-prem SharePoint REST's
+   * `_api/web` provides — see SharePointService.resolveSiteFromUrl for that
+   * on-prem equivalent). So this walks the path from longest to shortest
+   * prefix, trying each as a candidate site path, until one resolves.
+   *
+   * Once the site is found, the remaining path suffix (what's left after
+   * the matched site path) is resolved against that site's default drive
+   * via the documented `/sites/{siteId}/drive/root:/{path}:` addressing.
+   */
+  private async resolveFolderByPath(
+    hostname: string,
+    folderPath: string,
+    accessToken: string
+  ): Promise<{ driveId: string; itemId: string }> {
+    const segments = folderPath.split('/').filter(Boolean);
+
+    for (let splitAt = segments.length; splitAt >= 1; splitAt--) {
+      const candidateSitePath = segments.slice(0, splitAt).join('/');
+      const encodedSitePath = candidateSitePath
+        .split('/')
+        .map((segment) => encodeURIComponent(segment))
+        .join('/');
+
+      let siteResponse: any;
+      try {
+        siteResponse = await this.get(`${GRAPH_BASE_URL}/sites/${hostname}:/${encodedSitePath}`, accessToken);
+      } catch (error: any) {
+        // A 404 here just means this prefix isn't the site boundary — keep
+        // walking to a shorter prefix. Any other failure (401/403/network)
+        // is real and should surface immediately, not be swallowed by the
+        // walk loop.
+        if (error.message && error.message.includes('not found')) continue;
+        throw error;
+      }
+
+      const siteId = siteResponse.data.id;
+      const remainingSegments = segments.slice(splitAt);
+      if (remainingSegments.length === 0) {
+        throw new Error('This link points to a site, not a folder inside a document library');
+      }
+      const remainingPath = remainingSegments.map((segment) => encodeURIComponent(segment)).join('/');
+
+      const folderResponse = await this.get(`${GRAPH_BASE_URL}/sites/${siteId}/drive/root:/${remainingPath}:`, accessToken);
+      return { driveId: folderResponse.data.parentReference?.driveId, itemId: folderResponse.data.id };
+    }
+
+    throw new Error('Could not resolve a SharePoint site from this folder link');
+  }
+
+  /**
+   * Downloads Graph's own pre-signed @microsoft.graph.downloadUrl. No
+   * Authorization header is sent — Graph already scoped and signed this URL
+   * to the specific item, so our bearer token never reaches that host.
+   * Still validated (https + not a private/loopback address) rather than
+   * followed blindly, since a compromised/mistaken Graph response or
+   * redirect chain must not be able to point this at an internal address.
+   */
+  async downloadFile(downloadUrl: string): Promise<Buffer> {
+    const parsed = new URL(downloadUrl);
+    if (parsed.protocol !== 'https:') {
+      throw new Error('Refusing to fetch a non-https download URL');
+    }
+    if (this.isPrivateHost(parsed.hostname)) {
+      throw new Error('Refusing to fetch a download URL pointing at a private/internal host');
+    }
+    const response = await axios.get(downloadUrl, { responseType: 'arraybuffer' });
+    return Buffer.from(response.data);
+  }
+
+  /**
+   * Resolves whichever URL shape was pasted (see parseAllItemsFolderPath's
+   * doc comment) down to the Graph "list children of this folder" URL — the
+   * one piece every public method here actually needs.
+   */
+  private async resolveRootChildrenUrl(url: string, accessToken: string): Promise<string> {
+    if (!isMicrosoftSharingUrl(url)) {
+      throw new Error(
+        'That doesn’t look like a SharePoint or OneDrive link — expected a sharepoint.com, onedrive.com, or 1drv.ms URL'
+      );
+    }
+
+    const browsedFolder = parseAllItemsFolderPath(url);
+    if (browsedFolder) {
+      const { driveId, itemId } = await this.resolveFolderByPath(browsedFolder.hostname, browsedFolder.folderPath, accessToken);
+      return `${GRAPH_BASE_URL}/drives/${driveId}/items/${itemId}/children`;
+    }
+
+    const shareId = this.encodeShareId(url);
+    return `${GRAPH_BASE_URL}/shares/${shareId}/driveItem/children`;
+  }
+
+  /**
+   * Cheapest possible check that a pasted folder link + token combination
+   * actually resolves — one call, no recursive listing.
+   */
+  async testShareAccess(
+    shareUrl: string,
+    token: SharePointOAuthToken
+  ): Promise<{ success: boolean; message: string }> {
+    try {
+      const childrenUrl = await this.resolveRootChildrenUrl(shareUrl, token.accessToken);
+      await this.get(childrenUrl, token.accessToken);
+      return { success: true, message: 'Successfully connected to SharePoint via Microsoft Graph' };
+    } catch (error: any) {
+      return { success: false, message: error.message || 'Connection failed' };
+    }
+  }
+
+  /**
+   * Follows @odata.nextLink so libraries over the 200-item Graph page size
+   * are still fully listed.
+   */
+  private async listChildren(url: string, accessToken: string): Promise<any[]> {
+    const items: any[] = [];
+    let nextUrl: string | undefined = url;
+    while (nextUrl) {
+      const response = await this.get(nextUrl, accessToken);
+      items.push(...(response.data.value || []));
+      nextUrl = response.data['@odata.nextLink'];
+    }
+    return items;
+  }
+
+  /**
+   * Lists all Word template files one level below the shared folder's
+   * subfolders. Same docType convention as the on-prem path: each
+   * subfolder's name becomes the docType, and only .docx/.dotx files are
+   * returned. Emits the same SharePointFile shape the on-prem path uses —
+   * `serverRelativeUrl` carries Graph's pre-signed download URL instead of a
+   * server-relative path, which is exactly what downloadFile() expects back.
+   */
+  async listTemplateFiles(shareUrl: string, token: SharePointOAuthToken): Promise<SharePointFile[]> {
+    const rootChildrenUrl = await this.resolveRootChildrenUrl(shareUrl, token.accessToken);
+    const subfolders = await this.listChildren(rootChildrenUrl, token.accessToken);
+
+    const allTemplateFiles: SharePointFile[] = [];
+
+    for (const subfolder of subfolders) {
+      if (!subfolder.folder) continue; // only folders are docType buckets
+
+      const subfolderName = subfolder.name;
+      if (subfolderName.startsWith('_') || subfolderName.startsWith('.')) continue;
+
+      const driveId = subfolder.parentReference?.driveId;
+      const itemId = subfolder.id;
+      if (!driveId || !itemId) {
+        logger.warn(`Skipping SharePoint subfolder "${subfolderName}" — missing driveId/itemId in Graph response`);
+        continue;
+      }
+
+      const children = await this.listChildren(`${GRAPH_BASE_URL}/drives/${driveId}/items/${itemId}/children`, token.accessToken);
+
+      const templateFiles = children.filter((file: any) => {
+        if (file.folder) return false;
+        if (!isTemplateFileName(file.name)) return false;
+        if (!isWithinMaxTemplateSize(Number(file.size))) {
+          logger.warn(`Skipping SharePoint file "${file.name}" — size ${file.size} bytes exceeds the sync limit`);
+          return false;
+        }
+        return true;
+      });
+
+      for (const file of templateFiles) {
+        const downloadUrl = file['@microsoft.graph.downloadUrl'];
+        if (!downloadUrl) {
+          logger.warn(`Skipping SharePoint file "${file.name}" — Graph did not return a download URL`);
+          continue;
+        }
+        allTemplateFiles.push({
+          name: file.name,
+          serverRelativeUrl: downloadUrl,
+          timeCreated: file.createdDateTime,
+          timeLastModified: file.lastModifiedDateTime,
+          length: file.size,
+          docType: subfolderName,
+        });
+      }
+
+      logger.info(`Found ${templateFiles.length} template files in "${subfolderName}" (Graph)`);
+    }
+
+    logger.info(`Total template files found via Graph: ${allTemplateFiles.length}`);
+
+    return allTemplateFiles;
+  }
+}

--- a/src/services/GraphSharePointService.ts
+++ b/src/services/GraphSharePointService.ts
@@ -12,8 +12,21 @@ import {
 } from './SharePointService';
 import { withThrottleRetry, createRetryBudget, RetryBudget, RETRYABLE_STATUSES, REQUEST_TIMEOUT_MS } from './sharePointRetry';
 import { isTemplateFileName, isWithinMaxTemplateSize } from './sharePointFileValidation';
+import { assertGraphApiUrl, assertDownloadUrl } from '../util/graphUrlGuard';
+import { GraphTokenProvider } from './auth/MsalClientService';
 
 const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+
+// Accepts a plain { accessToken } object or a GraphTokenProvider closure
+// (which re-acquires per call — see MsalClientService.createTokenProvider
+// for why that matters on a long-running sync). Normalized to a provider
+// internally so the rest of this class deals with one shape.
+export type TokenSource = SharePointOAuthToken | GraphTokenProvider;
+
+function toTokenProvider(source: TokenSource): GraphTokenProvider {
+  if (typeof source === 'function') return source;
+  return async () => source.accessToken;
+}
 
 // One BFS queue entry — a folder's "list children" URL still to walk.
 // `relativePath` is that folder's own path relative to the shared root
@@ -49,52 +62,12 @@ function isMicrosoftSharingUrl(url: string): boolean {
 }
 
 /**
- * Two distinct URL shapes reach this code in practice:
- *
- *  1. A "Copy Link" sharing URL (what SharePoint's Share dialog issues),
- *     e.g. https://tenant.sharepoint.com/:f:/r/teams/x/Shared Documents/y?d=<id>&...
- *     Graph's /shares endpoint is Microsoft's documented mechanism for
- *     resolving exactly this kind of token-bearing sharing URL directly to
- *     a driveItem.
- *
- *  2. A plain browsed-folder address-bar URL — what a user gets by
- *     navigating into the folder and copying the URL, NOT clicking "Copy
- *     Link". This is actually the far more common case in practice. Its
- *     shape is a library view page (.../Forms/AllItems.aspx) with the real
- *     folder identified by a `?...&id=<url-encoded-server-relative-path>`
- *     query parameter that SharePoint's page script reads client-side —
- *     Graph has no built-in understanding of this `id=` convention, and
- *     resolving the *page* URL via /shares would likely resolve to the
- *     library root or the page itself, not the nested folder — a silent
- *     wrong-target risk, worse than an outright error.
- *
- * This distinguishes the two by checking for a path-shaped `id` query
- * parameter, and returns the decoded server-relative folder path for shape
- * 2 so callers can resolve it via site-path walking instead of /shares.
- */
-function parseAllItemsFolderPath(url: string): { hostname: string; folderPath: string } | null {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return null;
-  }
-  const idParam = parsed.searchParams.get('id');
-  if (!idParam || !idParam.startsWith('/')) return null;
-  return { hostname: parsed.hostname, folderPath: decodeURIComponent(idParam) };
-}
-
-/**
- * Reads a SharePoint/OneDrive folder from a user-pasted URL, using a bearer
- * token supplied by the caller (e.g. pasted from Graph Explorer). Accepts
- * two distinct URL shapes a user might actually paste — see
- * parseAllItemsFolderPath's doc comment for why they need different
- * resolution paths:
- *  - a "Copy Link" sharing URL, resolved via Graph's /shares endpoint
- *    (mirrors the pattern already proven in req2ado's graph_client.py)
- *  - a plain browsed-folder address-bar URL, resolved by walking the
- *    server-relative path to find its site, then addressing the remaining
- *    path within that site's default drive
+ * Reads a SharePoint/OneDrive folder from a user-pasted URL via Microsoft
+ * Graph's /shares endpoint — the single resolution path for both URL shapes
+ * a user might paste ("Copy Link" sharing URLs and plain browsed-folder
+ * address-bar URLs), both resolvable under delegated Files.Read.All alone.
+ * There is deliberately no /sites/{hostname}:/{path} fallback, since that
+ * path requires Sites.Read.All, which this app does not request.
  */
 export class GraphSharePointService {
   /**
@@ -102,7 +75,7 @@ export class GraphSharePointService {
    * expects: "u!" + unpadded base64url(url). See:
    * https://learn.microsoft.com/graph/api/shares-get
    *
-   * Single choke point for both public methods below — validates the URL is
+   * Single choke point for every public method below — validates the URL is
    * actually a Microsoft SharePoint/OneDrive link *before* any network call,
    * rather than letting a mispasted URL fail deep inside the Graph request.
    */
@@ -119,8 +92,8 @@ export class GraphSharePointService {
 
   private errorForStatus(status: number): Error {
     const messages: Record<number, string> = {
-      401: 'Graph access token expired or invalid — paste a fresh one',
-      403: 'This token does not have permission to read this SharePoint folder',
+      401: 'Graph access token expired or invalid — please sign in again',
+      403: 'This account does not have permission to read this SharePoint folder',
       404: 'SharePoint folder not found for this sharing link',
     };
     // Carry the real status through so callers can respond 4xx (an expired
@@ -133,33 +106,29 @@ export class GraphSharePointService {
 
   /**
    * `retryBudget`, when passed, is shared across every request in one
-   * `listTemplateFiles` walk — see sharePointRetry.ts's doc comment for why
-   * that matters once folder fetches run concurrently. Callers that don't
-   * pass one (testShareAccess, resolveFolderByPath's candidate-path walk,
-   * etc.) still get up to 2 retries per call, just not budget-capped across
-   * calls — acceptable since only genuine 429/503 responses are retryable,
-   * never the 404s that walk expects from a wrong candidate.
+   * `listTemplateFiles` walk (see sharePointRetry.ts for why that matters
+   * once folder fetches run concurrently). Callers that don't pass one
+   * still get up to 2 retries per call, just not budget-capped across calls.
+   *
+   * `tokenProvider` is invoked on every call, not cached here — lets a
+   * MsalClientService.createTokenProvider-backed caller silently refresh
+   * mid-walk instead of reusing one token across a download loop that can
+   * outlive its 60-90 minute lifetime.
+   *
+   * No `Prefer: redeemSharingLinkIfNecessary` header is sent — redeeming a
+   * sharing link is a permission-granting side effect, and this app must
+   * stay read-only in effect, not just in the scopes it holds.
+   * Files.Read.All alone resolves /shares without it.
    */
-  private async get(url: string, accessToken: string, retryBudget?: RetryBudget): Promise<any> {
+  private async get(url: string, tokenProvider: GraphTokenProvider, retryBudget?: RetryBudget): Promise<any> {
     return withThrottleRetry(
-      () =>
-        axios.get(url, {
+      async () => {
+        const accessToken = await tokenProvider();
+        return axios.get(url, {
           timeout: REQUEST_TIMEOUT_MS,
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            // Documented specifically for /shares/...: without it, Graph may
-            // refuse to fully resolve a sharing link the caller hasn't
-            // "redeemed" before (equivalent to a user never having opened the
-            // link in a browser under this identity), surfacing as a 403 even
-            // with a token that holds sufficient Files.Read.All/Sites.Read.All
-            // scope. "IfNecessary" only grants access for this request's
-            // duration, matching what a read-only template sync needs. Sent
-            // on every call, not just /shares — Prefer is advisory HTTP, and
-            // the /sites and /drives endpoints this service also calls simply
-            // ignore a Prefer value they don't recognize.
-            Prefer: 'redeemSharingLinkIfNecessary',
-          },
-        }),
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+      },
       (outcome) => {
         const status = outcome.error?.response?.status;
         return {
@@ -182,124 +151,58 @@ export class GraphSharePointService {
     });
   }
 
-  private isPrivateHost(hostname: string): boolean {
-    return (
-      hostname === 'localhost' ||
-      /^127\./.test(hostname) ||
-      /^10\./.test(hostname) ||
-      /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname) ||
-      /^192\.168\./.test(hostname) ||
-      /^169\.254\./.test(hostname)
-    );
-  }
-
   /**
-   * Resolves a browsed folder's server-relative path (extracted from an
-   * AllItems.aspx `id=` query param) to a folder driveItem, without ever
-   * assuming where the site boundary sits within that path — Graph's
-   * `/sites/{hostname}:/{path}` 404s unless `{path}` is exactly a site's own
-   * path (no "nearest site" resolution the way on-prem SharePoint REST's
-   * `_api/web` provides — see SharePointService.resolveSiteFromUrl for that
-   * on-prem equivalent). So this walks the path from longest to shortest
-   * prefix, trying each as a candidate site path, until one resolves.
-   *
-   * Once the site is found, the remaining path suffix (what's left after
-   * the matched site path) is resolved against that site's default drive
-   * via the documented `/sites/{siteId}/drive/root:/{path}:` addressing.
+   * Resolves whichever URL shape was pasted down to the Graph "list
+   * children of this folder" URL — the one piece every listing/testing
+   * method here actually needs. Purely a string transform (encodeShareId
+   * validates and encodes; no network call), which is why this isn't async.
    */
-  private async resolveFolderByPath(
-    hostname: string,
-    folderPath: string,
-    accessToken: string
-  ): Promise<{ driveId: string; itemId: string }> {
-    const segments = folderPath.split('/').filter(Boolean);
-
-    for (let splitAt = segments.length; splitAt >= 1; splitAt--) {
-      const candidateSitePath = segments.slice(0, splitAt).join('/');
-      const encodedSitePath = candidateSitePath
-        .split('/')
-        .map((segment) => encodeURIComponent(segment))
-        .join('/');
-
-      let siteResponse: any;
-      try {
-        siteResponse = await this.get(`${GRAPH_BASE_URL}/sites/${hostname}:/${encodedSitePath}`, accessToken);
-      } catch (error: any) {
-        // A 404 here just means this prefix isn't the site boundary — keep
-        // walking to a shorter prefix. Any other failure (401/403/network)
-        // is real and should surface immediately, not be swallowed by the
-        // walk loop.
-        if (error.message && error.message.includes('not found')) continue;
-        throw error;
-      }
-
-      const siteId = siteResponse.data.id;
-      const remainingSegments = segments.slice(splitAt);
-      if (remainingSegments.length === 0) {
-        throw new Error('This link points to a site, not a folder inside a document library');
-      }
-      const remainingPath = remainingSegments.map((segment) => encodeURIComponent(segment)).join('/');
-
-      const folderResponse = await this.get(`${GRAPH_BASE_URL}/sites/${siteId}/drive/root:/${remainingPath}:`, accessToken);
-      return { driveId: folderResponse.data.parentReference?.driveId, itemId: folderResponse.data.id };
-    }
-
-    throw new Error('Could not resolve a SharePoint site from this folder link');
-  }
-
-  /**
-   * Downloads Graph's own pre-signed @microsoft.graph.downloadUrl. No
-   * Authorization header is sent — Graph already scoped and signed this URL
-   * to the specific item, so our bearer token never reaches that host.
-   * Still validated (https + not a private/loopback address) rather than
-   * followed blindly, since a compromised/mistaken Graph response or
-   * redirect chain must not be able to point this at an internal address.
-   */
-  async downloadFile(downloadUrl: string): Promise<Buffer> {
-    const parsed = new URL(downloadUrl);
-    if (parsed.protocol !== 'https:') {
-      throw new Error('Refusing to fetch a non-https download URL');
-    }
-    if (this.isPrivateHost(parsed.hostname)) {
-      throw new Error('Refusing to fetch a download URL pointing at a private/internal host');
-    }
-    const response = await axios.get(downloadUrl, { responseType: 'arraybuffer' });
-    return Buffer.from(response.data);
-  }
-
-  /**
-   * Resolves whichever URL shape was pasted (see parseAllItemsFolderPath's
-   * doc comment) down to the Graph "list children of this folder" URL — the
-   * one piece every public method here actually needs.
-   */
-  private async resolveRootChildrenUrl(url: string, accessToken: string): Promise<string> {
-    if (!isMicrosoftSharingUrl(url)) {
-      throw new Error(
-        'That doesn’t look like a SharePoint or OneDrive link — expected a sharepoint.com, onedrive.com, or 1drv.ms URL'
-      );
-    }
-
-    const browsedFolder = parseAllItemsFolderPath(url);
-    if (browsedFolder) {
-      const { driveId, itemId } = await this.resolveFolderByPath(browsedFolder.hostname, browsedFolder.folderPath, accessToken);
-      return `${GRAPH_BASE_URL}/drives/${driveId}/items/${itemId}/children`;
-    }
-
+  private resolveRootChildrenUrl(url: string): string {
     const shareId = this.encodeShareId(url);
     return `${GRAPH_BASE_URL}/shares/${shareId}/driveItem/children`;
   }
 
   /**
-   * Cheapest possible check that a pasted folder link + token combination
-   * actually resolves — one call, no recursive listing.
+   * Resolves a pasted SharePoint/OneDrive URL to a concrete {driveId,
+   * itemId}. Not currently called by any controller/service — listing and
+   * downloading both resolve fresh from the pasted URL on every call
+   * instead (see resolveRootChildrenUrl). Exists for SharePointResolvedRoot
+   * (also unused today) if that binding is wired in later.
    */
-  async testShareAccess(
-    shareUrl: string,
-    token: SharePointOAuthToken
-  ): Promise<{ success: boolean; message: string }> {
+  async resolveShareRoot(url: string, tokenSource: TokenSource): Promise<{ driveId: string; itemId: string; name?: string }> {
+    const tokenProvider = toTokenProvider(tokenSource);
+    const shareId = this.encodeShareId(url);
+    const response = await this.get(`${GRAPH_BASE_URL}/shares/${shareId}/driveItem`, tokenProvider);
+    const driveId = response.data?.parentReference?.driveId;
+    const itemId = response.data?.id;
+    if (!driveId || !itemId) {
+      throw new Error('Could not resolve a drive/item reference from this SharePoint link');
+    }
+    return { driveId, itemId, name: response.data?.name };
+  }
+
+  /**
+   * Downloads Graph's own pre-signed @microsoft.graph.downloadUrl. No
+   * Authorization header is sent — Graph already scoped and signed it to
+   * the specific item. Still validated against an explicit host allowlist
+   * (graphUrlGuard) rather than followed blindly, in case a compromised or
+   * malformed response points it at an internal address.
+   */
+  async downloadFile(downloadUrl: string): Promise<Buffer> {
+    assertDownloadUrl(downloadUrl);
+    const response = await axios.get(downloadUrl, { responseType: 'arraybuffer' });
+    return Buffer.from(response.data);
+  }
+
+  /**
+   * Cheapest possible check that a pasted folder link + credential actually
+   * resolves — one call, no recursive listing.
+   */
+  async testShareAccess(shareUrl: string, tokenSource: TokenSource): Promise<{ success: boolean; message: string }> {
     try {
-      const childrenUrl = await this.resolveRootChildrenUrl(shareUrl, token.accessToken);
-      await this.get(childrenUrl, token.accessToken);
+      const tokenProvider = toTokenProvider(tokenSource);
+      const childrenUrl = this.resolveRootChildrenUrl(shareUrl);
+      await this.get(childrenUrl, tokenProvider);
       return { success: true, message: 'Successfully connected to SharePoint via Microsoft Graph' };
     } catch (error: any) {
       return { success: false, message: error.message || 'Connection failed' };
@@ -308,13 +211,16 @@ export class GraphSharePointService {
 
   /**
    * Follows @odata.nextLink so libraries over the 200-item Graph page size
-   * are still fully listed.
+   * are still fully listed. Every URL, including the first, is
+   * host-validated via assertGraphApiUrl first — an off-host nextLink would
+   * otherwise replay this app's Graph access token to an attacker's server.
    */
-  private async listChildren(url: string, accessToken: string, retryBudget?: RetryBudget): Promise<any[]> {
+  private async listChildren(url: string, tokenProvider: GraphTokenProvider, retryBudget?: RetryBudget): Promise<any[]> {
     const items: any[] = [];
     let nextUrl: string | undefined = url;
     while (nextUrl) {
-      const response = await this.get(nextUrl, accessToken, retryBudget);
+      assertGraphApiUrl(nextUrl);
+      const response = await this.get(nextUrl, tokenProvider, retryBudget);
       items.push(...(response.data.value || []));
       nextUrl = response.data['@odata.nextLink'];
     }
@@ -335,8 +241,9 @@ export class GraphSharePointService {
    * download URL instead of a server-relative path, which is exactly what
    * downloadFile() expects back.
    */
-  async listTemplateFiles(shareUrl: string, token: SharePointOAuthToken): Promise<SharePointFileListing> {
-    const rootChildrenUrl = await this.resolveRootChildrenUrl(shareUrl, token.accessToken);
+  async listTemplateFiles(shareUrl: string, tokenSource: TokenSource): Promise<SharePointFileListing> {
+    const tokenProvider = toTokenProvider(tokenSource);
+    const rootChildrenUrl = this.resolveRootChildrenUrl(shareUrl);
 
     const queue: GraphFolderQueueItem[] = [{ childrenUrl: rootChildrenUrl, relativePath: '', depth: 0 }];
 
@@ -362,7 +269,7 @@ export class GraphSharePointService {
     // keeps output deterministic under concurrency.
     while (queue.length > 0 && !truncated) {
       const batch = queue.splice(0, CONCURRENT_FOLDER_FETCHES);
-      const results = await Promise.all(batch.map((item) => this.fetchFolder(token, item, retryBudget)));
+      const results = await Promise.all(batch.map((item) => this.fetchFolder(tokenProvider, item, retryBudget)));
 
       for (const result of results) {
         if (truncated) break;
@@ -413,7 +320,7 @@ export class GraphSharePointService {
    * caller, in queue order, once every promise in a batch has settled).
    */
   private async fetchFolder(
-    token: SharePointOAuthToken,
+    tokenProvider: GraphTokenProvider,
     item: GraphFolderQueueItem,
     retryBudget: RetryBudget
   ): Promise<GraphFetchFolderResult> {
@@ -421,7 +328,7 @@ export class GraphSharePointService {
 
     let children: any[];
     try {
-      children = await this.listChildren(childrenUrl, token.accessToken, retryBudget);
+      children = await this.listChildren(childrenUrl, tokenProvider, retryBudget);
     } catch (err: any) {
       if (err.status === 403 && depth > 0) {
         logger.warn(`Skipping inaccessible folder "${relativePath}" (Graph): ${err.message}`);

--- a/src/services/SharePointService.ts
+++ b/src/services/SharePointService.ts
@@ -3,6 +3,7 @@ import https from 'https';
 import logger from '../util/logger';
 import { GraphSharePointService } from './GraphSharePointService';
 import { isTemplateFileName, isWithinMaxTemplateSize, hasZipSignature } from './sharePointFileValidation';
+import { GraphTokenProvider } from './auth/MsalClientService';
 import {
   withThrottleRetry,
   createRetryBudget,
@@ -111,14 +112,38 @@ export interface SharePointConfig {
   folder: string;
 }
 
+// Three shapes: a plain NTLM credentials object, a plain { accessToken }
+// object, or a GraphTokenProvider closure (the session-backed flow). The
+// two OAuth-shaped alternatives are narrowed together via isTokenBased.
+type SharePointAuth = SharePointCredentials | SharePointOAuthToken | GraphTokenProvider;
+
+// Detects if a SharePoint URL is SharePoint Online or On-Premise. Exported
+// standalone (not just the class's private wrapper below) so callers like
+// SharePointController can use the exact same signal to decide which auth
+// shape a request needs, without instantiating SharePointService just for
+// this check — single source of truth for what "Online" means.
+export function isSharePointOnlineUrl(siteUrl: string): boolean {
+  return siteUrl.toLowerCase().includes('.sharepoint.com');
+}
+
 export class SharePointService {
   private graphService = new GraphSharePointService();
+
+  /**
+   * True for anything OAuth/Graph-shaped (a plain { accessToken } object or
+   * a GraphTokenProvider closure) — false only for plain NTLM credentials.
+   * A user-defined type guard so callers get real narrowing when they check
+   * it inline, rather than needing a manual cast at every branch.
+   */
+  private isTokenBased(auth: SharePointAuth): auth is SharePointOAuthToken | GraphTokenProvider {
+    return typeof auth === 'function' || 'accessToken' in auth;
+  }
 
   /**
    * Detects if the SharePoint URL is SharePoint Online or On-Premise
    */
   private isSharePointOnline(siteUrl: string): boolean {
-    return siteUrl.toLowerCase().includes('.sharepoint.com');
+    return isSharePointOnlineUrl(siteUrl);
   }
 
   /**
@@ -376,13 +401,13 @@ export class SharePointService {
    */
   async testConnection(
     config: SharePointConfig,
-    credentials: SharePointCredentials | SharePointOAuthToken
+    credentials: SharePointAuth
   ): Promise<{ success: boolean; message: string }> {
     try {
       const isOnline = this.isSharePointOnline(config.siteUrl);
 
       if (isOnline) {
-        if (!('accessToken' in credentials)) {
+        if (!this.isTokenBased(credentials)) {
           return {
             success: false,
             message: 'SharePoint Online requires a Microsoft Graph access token, not a username/password.',
@@ -393,7 +418,7 @@ export class SharePointService {
         return this.graphService.testShareAccess(config.siteUrl, credentials);
       }
 
-      if ('accessToken' in credentials) {
+      if (this.isTokenBased(credentials)) {
         return {
           success: false,
           message: 'On-premise SharePoint requires a username/password, not a Microsoft Graph token.',
@@ -450,11 +475,11 @@ export class SharePointService {
    */
   async listTemplateFiles(
     config: SharePointConfig,
-    credentials: SharePointCredentials | SharePointOAuthToken
+    credentials: SharePointAuth
   ): Promise<SharePointFileListing> {
     try {
       const isOnline = this.isSharePointOnline(config.siteUrl);
-      const isOAuth = 'accessToken' in credentials;
+      const isOAuth = this.isTokenBased(credentials);
 
       if (isOnline && isOAuth) {
         // config.siteUrl doubles as the pasted SharePoint/OneDrive sharing
@@ -566,7 +591,7 @@ export class SharePointService {
    */
   private async fetchFolder(
     config: SharePointConfig,
-    credentials: SharePointCredentials | SharePointOAuthToken,
+    credentials: SharePointAuth,
     isOAuth: boolean,
     item: FolderQueueItem,
     retryBudget: RetryBudget
@@ -676,10 +701,10 @@ export class SharePointService {
   async downloadFile(
     siteUrl: string,
     serverRelativeUrl: string,
-    auth: SharePointCredentials | SharePointOAuthToken
+    auth: SharePointAuth
   ): Promise<Buffer> {
     try {
-      const isOAuth = 'accessToken' in auth;
+      const isOAuth = this.isTokenBased(auth);
       let buffer: Buffer;
 
       if (this.isSharePointOnline(siteUrl) && isOAuth) {
@@ -730,12 +755,12 @@ export class SharePointService {
    */
   private async makeSharePointRequest(
     url: string,
-    auth: SharePointCredentials | SharePointOAuthToken,
+    auth: SharePointAuth,
     method: string = 'GET',
     additionalConfig: any = {},
     retryBudget?: RetryBudget
   ): Promise<any> {
-    const isOAuth = 'accessToken' in auth;
+    const isOAuth = this.isTokenBased(auth);
     const configWithTimeout = { timeout: REQUEST_TIMEOUT_MS, ...additionalConfig };
 
     return withThrottleRetry(

--- a/src/services/SharePointService.ts
+++ b/src/services/SharePointService.ts
@@ -1,6 +1,19 @@
 import axios, { AxiosRequestConfig } from 'axios';
+import https from 'https';
 import logger from '../util/logger';
-import { ConfidentialClientApplication } from '@azure/msal-node';
+import { GraphSharePointService } from './GraphSharePointService';
+import { isTemplateFileName, isWithinMaxTemplateSize, hasZipSignature } from './sharePointFileValidation';
+
+// On-prem SharePoint often sits behind a self-signed / internal-CA certificate.
+// Prefer NODE_EXTRA_CA_CERTS (trusts the internal CA at the Node level, covers
+// axios and httpntlm alike) for production. This flag is a dev-only escape
+// hatch — never enable it in production, it disables TLS verification.
+const ALLOW_SELF_SIGNED = process.env.SHAREPOINT_ALLOW_SELF_SIGNED === 'true';
+if (ALLOW_SELF_SIGNED) {
+  logger.warn(
+    'SHAREPOINT_ALLOW_SELF_SIGNED=true — SharePoint TLS certificate validation is disabled. Do not use in production.'
+  );
+}
 
 // SharePoint credentials interface (for NTLM - on-premise)
 export interface SharePointCredentials {
@@ -20,6 +33,7 @@ export interface SharePointOAuthToken {
 export interface SharePointFile {
   name: string;
   serverRelativeUrl: string;
+  timeCreated?: string;
   timeLastModified: string;
   length: number;
   docType?: string; // Detected from parent folder name
@@ -33,6 +47,8 @@ export interface SharePointConfig {
 }
 
 export class SharePointService {
+  private graphService = new GraphSharePointService();
+
   /**
    * Detects if the SharePoint URL is SharePoint Online or On-Premise
    */
@@ -55,14 +71,139 @@ export class SharePointService {
   }
 
   /**
-   * Constructs the full folder path for SharePoint REST API
+   * Constructs the full folder path for SharePoint REST API.
+   *
+   * `library`/`folder` are joined with `.filter(Boolean)` rather than a bare
+   * template string: a config resolved via `resolveSiteFromUrl()` stores the
+   * whole remaining path in `folder` and leaves `library` empty (there's no
+   * longer a separate library field once the user pastes one full folder
+   * URL), and a bare `${library}/${folder}` would produce a doubled slash
+   * (an empty path segment) whenever `library` is blank.
    */
   private constructFolderPath(config: SharePointConfig): string {
     const sitePath = this.extractSitePath(config.siteUrl);
     // Remove trailing slash from site path
     const cleanSitePath = sitePath.endsWith('/') ? sitePath.slice(0, -1) : sitePath;
-    // Construct full path
-    return `${cleanSitePath}/${config.library}/${config.folder}`;
+    return [cleanSitePath, config.library, config.folder].filter(Boolean).join('/');
+  }
+
+  /**
+   * Resolves a pasted on-prem templates-folder URL (copied straight from
+   * the browser's address bar) into a `SharePointConfig`-ready site root +
+   * folder path, so the user never has to split it into Site URL / Library
+   * / Folder by hand. The whole remaining path below the resolved site
+   * lands in `folder` (`library` is left empty) — `constructFolderPath`
+   * already tolerates an empty `library` (see its own doc comment) so this
+   * plugs straight into the existing sync flow unchanged.
+   *
+   * Uses `GET {url}/_api/web?$select=ServerRelativeUrl` rather than the
+   * more commonly-documented `/_api/contextinfo` operator: contextinfo is
+   * POST-only specifically because it also hands back a write-capable form
+   * digest that needs CSRF protection — we only need to *read* where the
+   * URL sits, so the plain `web` entry point (a normal GET, no new HTTP
+   * method support needed in makeNTLMRequest) does the same job. Both are
+   * reached through the same `_api` request-routing layer, which resolves
+   * the "nearest web" for any URL under the site, not just a site's own
+   * root URL — see "Navigate the SharePoint data structure represented in
+   * the REST service" on Microsoft Learn.
+   */
+  async resolveSiteFromUrl(
+    pastedUrl: string,
+    credentials: SharePointCredentials
+  ): Promise<{ siteUrl: string; library: string; folder: string }> {
+    try {
+      const parsedUrl = new URL(pastedUrl);
+      // Use the URL's own path only — a pasted AllItems.aspx link carries a
+      // query string (?web=1&RootFolder=...&FolderCTID=...), and appending
+      // /_api/web onto that unstripped would glue our API path onto the end
+      // of whatever query param happens to be last, never actually reaching
+      // _api/web. The page path alone is enough for _api/web's "nearest
+      // site" routing to resolve the site boundary. Strip the query string
+      // by taking only the base URL (scheme + origin + path), preserving
+      // the exact encoding of the pasted URL.
+      const baseUrlString = pastedUrl.split('?')[0];
+      const baseUrl = baseUrlString.replace(/\/+$/, '');
+      const apiUrl = `${baseUrl}/_api/web?$select=ServerRelativeUrl`;
+
+      logger.info(`Resolving SharePoint site from pasted URL: ${baseUrl}`);
+
+      const response = await this.makeNTLMRequest(apiUrl, credentials, 'GET');
+      const serverRelativeUrl = response?.data?.d?.ServerRelativeUrl;
+
+      if (typeof serverRelativeUrl !== 'string') {
+        const contentType = response?.headers?.['content-type'] || 'unknown';
+        const bodyPreview =
+          typeof response?.data === 'string'
+            ? response.data.slice(0, 200)
+            : JSON.stringify(response?.data).slice(0, 200);
+        throw new Error(
+          `Could not resolve a SharePoint site from this URL (content-type: ${contentType}). Body preview: ${bodyPreview}`
+        );
+      }
+
+      // A browsed AllItems.aspx URL (on-prem's equivalent of Online's
+      // ?id=... shape) carries the real target folder in ?RootFolder=...,
+      // not in the page's own path — the page path is just the library's
+      // Forms view. Prefer it when present; fall back to the URL's own path
+      // for a direct folder link that has no RootFolder param.
+      const rootFolderParam = parsedUrl.searchParams.get('RootFolder');
+      const fullPath = rootFolderParam ?? decodeURIComponent(parsedUrl.pathname);
+      // fullPath includes the site's own path prefix (serverRelativeUrl) —
+      // strip it so `folder` is relative to the site, not duplicated when
+      // constructFolderPath re-prepends the site path.
+      const folder = fullPath.startsWith(serverRelativeUrl)
+        ? fullPath.slice(serverRelativeUrl.length).replace(/^\/+/, '')
+        : fullPath.replace(/^\/+/, '');
+
+      return {
+        siteUrl: `${parsedUrl.origin}${serverRelativeUrl}`,
+        library: '',
+        folder,
+      };
+    } catch (error: any) {
+      logger.error(`Failed to resolve SharePoint site from URL: ${error.message}`);
+      throw new Error(`Failed to resolve SharePoint site from URL: ${error.message}`);
+    }
+  }
+
+  /**
+   * Builds the server-relative-URL literal used inside
+   * GetFolderByServerRelativeUrl('...') / GetFileByServerRelativeUrl('...').
+   * Two encoding rules apply, per the SharePoint REST/OData conventions:
+   *  - a literal single quote inside an OData string literal must be escaped
+   *    by doubling it ('' ), otherwise the request 400s with a syntax error.
+   *  - each path SEGMENT is percent-encoded individually, never the whole
+   *    path — percent-encoding a '/' produces %2F, and IIS's request
+   *    filtering module rejects that by default (404.11 "URL Double
+   *    Escaped"; allowDoubleEscaping defaults to false — see
+   *    learn.microsoft.com/iis/configuration/system.webserver/security/requestfiltering).
+   *    encodeURIComponent() on the full path previously did exactly this.
+   */
+  private toServerRelativeUrlLiteral(path: string): string {
+    return path
+      .split('/')
+      .map((segment) => encodeURIComponent(segment.replace(/'/g, "''")))
+      .join('/');
+  }
+
+  /**
+   * Guards against a response that isn't the expected SharePoint REST JSON
+   * list shape ({ d: { results: [...] } }). Previously an unrecognised
+   * response (e.g. Atom XML returned when the NTLM request didn't send an
+   * Accept: application/json header) was silently treated as "no items",
+   * so a broken request reported a successful sync of zero files. Throws
+   * instead, logging enough to diagnose without leaking credentials.
+   */
+  private assertJsonListResponse(response: any, context: string): void {
+    if (response?.data?.d?.results) {
+      return;
+    }
+    const contentType = response?.headers?.['content-type'] || 'unknown';
+    const bodyPreview =
+      typeof response?.data === 'string' ? response.data.slice(0, 200) : JSON.stringify(response?.data).slice(0, 200);
+    throw new Error(
+      `Unexpected response fetching ${context} (content-type: ${contentType}). Body preview: ${bodyPreview}`
+    );
   }
 
   /**
@@ -70,21 +211,33 @@ export class SharePointService {
    */
   async testConnection(
     config: SharePointConfig,
-    credentials: SharePointCredentials
+    credentials: SharePointCredentials | SharePointOAuthToken
   ): Promise<{ success: boolean; message: string }> {
     try {
       const isOnline = this.isSharePointOnline(config.siteUrl);
-      
+
       if (isOnline) {
+        if (!('accessToken' in credentials)) {
+          return {
+            success: false,
+            message: 'SharePoint Online requires a Microsoft Graph access token, not a username/password.',
+          };
+        }
+        // config.siteUrl doubles as the pasted SharePoint/OneDrive sharing
+        // link for the Online/Graph path — library/folder are unused here.
+        return this.graphService.testShareAccess(config.siteUrl, credentials);
+      }
+
+      if ('accessToken' in credentials) {
         return {
           success: false,
-          message: 'SharePoint Online requires Azure AD app registration. Please use manual upload or contact IT for app credentials.',
+          message: 'On-premise SharePoint requires a username/password, not a Microsoft Graph token.',
         };
       }
 
       // Test connection to on-premise SharePoint
       const folderPath = this.constructFolderPath(config);
-      const apiUrl = `${config.siteUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folderPath)}')/Files`;
+      const apiUrl = `${config.siteUrl}/_api/web/GetFolderByServerRelativeUrl('${this.toServerRelativeUrlLiteral(folderPath)}')/Files`;
 
       logger.info(`Testing SharePoint connection to: ${apiUrl}`);
 
@@ -123,63 +276,71 @@ export class SharePointService {
       const isOnline = this.isSharePointOnline(config.siteUrl);
       const isOAuth = 'accessToken' in credentials;
 
+      if (isOnline && isOAuth) {
+        // config.siteUrl doubles as the pasted SharePoint/OneDrive sharing
+        // link for the Online/Graph path — library/folder are unused here.
+        return await this.graphService.listTemplateFiles(config.siteUrl, credentials);
+      }
+
       const folderPath = this.constructFolderPath(config);
-      
+
       // First, get list of subfolders
-      const foldersApiUrl = `${config.siteUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folderPath)}')/Folders`;
+      const foldersApiUrl = `${config.siteUrl}/_api/web/GetFolderByServerRelativeUrl('${this.toServerRelativeUrlLiteral(folderPath)}')/Folders`;
       
       logger.info(`Fetching subfolders from SharePoint: ${foldersApiUrl} (${isOAuth ? 'OAuth' : 'NTLM'})`);
       
       const foldersResponse = await this.makeSharePointRequest(foldersApiUrl, credentials, 'GET');
-      
+      this.assertJsonListResponse(foldersResponse, 'subfolders');
+
       const allTemplateFiles: SharePointFile[] = [];
-      
-      if (foldersResponse.data && foldersResponse.data.d && foldersResponse.data.d.results) {
-        const subfolders = foldersResponse.data.d.results;
-        
-        logger.info(`Found ${subfolders.length} subfolders in ${folderPath}`);
-        
-        // For each subfolder, get the files
-        for (const subfolder of subfolders) {
-          const subfolderName = subfolder.Name;
-          const subfolderPath = subfolder.ServerRelativeUrl;
-          
-          // Skip system folders
-          if (subfolderName.startsWith('_') || subfolderName.startsWith('.')) {
-            continue;
-          }
-          
-          const filesApiUrl = `${config.siteUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(subfolderPath)}')/Files`;
-          
-          logger.info(`Fetching files from subfolder: ${subfolderName}`);
-          
-          const filesResponse = await this.makeSharePointRequest(filesApiUrl, credentials, 'GET');
-          
-          if (filesResponse.data && filesResponse.data.d && filesResponse.data.d.results) {
-            const files = filesResponse.data.d.results;
-            
-            // Filter for Word template files
-            const templateFiles = files.filter((file: any) => {
-              const fileName = file.Name.toLowerCase();
-              return fileName.endsWith('.docx') || fileName.endsWith('.dotx');
-            });
-            
-            // Add files with docType from subfolder name
-            templateFiles.forEach((file: any) => {
-              allTemplateFiles.push({
-                name: file.Name,
-                serverRelativeUrl: file.ServerRelativeUrl,
-                timeLastModified: file.TimeLastModified,
-                length: file.Length,
-                docType: subfolderName, // Subfolder name becomes the docType
-              });
-            });
-            
-            logger.info(`Found ${templateFiles.length} template files in ${subfolderName}`);
-          }
+      const subfolders = foldersResponse.data.d.results;
+
+      logger.info(`Found ${subfolders.length} subfolders in ${folderPath}`);
+
+      // For each subfolder, get the files
+      for (const subfolder of subfolders) {
+        const subfolderName = subfolder.Name;
+        const subfolderPath = subfolder.ServerRelativeUrl;
+
+        // Skip system folders
+        if (subfolderName.startsWith('_') || subfolderName.startsWith('.')) {
+          continue;
         }
+
+        const filesApiUrl = `${config.siteUrl}/_api/web/GetFolderByServerRelativeUrl('${this.toServerRelativeUrlLiteral(subfolderPath)}')/Files`;
+
+        logger.info(`Fetching files from subfolder: ${subfolderName}`);
+
+        const filesResponse = await this.makeSharePointRequest(filesApiUrl, credentials, 'GET');
+        this.assertJsonListResponse(filesResponse, `files in subfolder "${subfolderName}"`);
+
+        const files = filesResponse.data.d.results;
+
+        // Filter for Word template files (excludes ~$ Office lock files and oversized files)
+        const templateFiles = files.filter((file: any) => {
+          if (!isTemplateFileName(file.Name)) return false;
+          if (!isWithinMaxTemplateSize(Number(file.Length))) {
+            logger.warn(`Skipping SharePoint file "${file.Name}" — size ${file.Length} bytes exceeds the sync limit`);
+            return false;
+          }
+          return true;
+        });
+
+        // Add files with docType from subfolder name
+        templateFiles.forEach((file: any) => {
+          allTemplateFiles.push({
+            name: file.Name,
+            serverRelativeUrl: file.ServerRelativeUrl,
+            timeCreated: file.TimeCreated,
+            timeLastModified: file.TimeLastModified,
+            length: file.Length,
+            docType: subfolderName, // Subfolder name becomes the docType
+          });
+        });
+
+        logger.info(`Found ${templateFiles.length} template files in ${subfolderName}`);
       }
-      
+
       logger.info(`Total template files found: ${allTemplateFiles.length}`);
 
       return allTemplateFiles;
@@ -200,15 +361,34 @@ export class SharePointService {
   ): Promise<Buffer> {
     try {
       const isOAuth = 'accessToken' in auth;
-      const fileUrl = `${siteUrl}/_api/web/GetFileByServerRelativeUrl('${encodeURIComponent(serverRelativeUrl)}')/$value`;
+      let buffer: Buffer;
 
-      logger.info(`Downloading file from SharePoint: ${serverRelativeUrl} (${isOAuth ? 'OAuth' : 'NTLM'})`);
+      if (this.isSharePointOnline(siteUrl) && isOAuth) {
+        // serverRelativeUrl carries Graph's pre-signed download URL for the
+        // Online/Graph path (see GraphSharePointService.listTemplateFiles) —
+        // it's fetched directly, no site/library/folder context needed.
+        logger.info(`Downloading file from SharePoint via Graph: ${serverRelativeUrl.slice(0, 80)}...`);
+        buffer = await this.graphService.downloadFile(serverRelativeUrl);
+      } else {
+        const fileUrl = `${siteUrl}/_api/web/GetFileByServerRelativeUrl('${this.toServerRelativeUrlLiteral(serverRelativeUrl)}')/$value`;
 
-      const response = await this.makeSharePointRequest(fileUrl, auth, 'GET', {
-        responseType: 'arraybuffer',
-      });
+        logger.info(`Downloading file from SharePoint: ${serverRelativeUrl} (${isOAuth ? 'OAuth' : 'NTLM'})`);
 
-      return Buffer.from(response.data);
+        const response = await this.makeSharePointRequest(fileUrl, auth, 'GET', {
+          responseType: 'arraybuffer',
+        });
+
+        buffer = Buffer.from(response.data);
+      }
+
+      // .docx/.dotx are ZIP (OPC) packages regardless of source — a file
+      // that isn't a real ZIP archive is not a valid Office document, no
+      // matter what its extension or SharePoint's reported mimetype claim.
+      if (!hasZipSignature(buffer)) {
+        throw new Error('not a valid Office document — failed content check');
+      }
+
+      return buffer;
     } catch (error: any) {
       logger.error(`Failed to download file ${serverRelativeUrl}: ${error.message}`);
       throw new Error(`Failed to download file: ${error.message}`);
@@ -254,6 +434,10 @@ export class SharePointService {
         ...additionalConfig,
       };
 
+      if (ALLOW_SELF_SIGNED) {
+        config.httpsAgent = new https.Agent({ rejectUnauthorized: false });
+      }
+
       const response = await axios(config);
       
       return {
@@ -277,16 +461,40 @@ export class SharePointService {
     additionalConfig: any = {}
   ): Promise<any> {
     const ntlm = require('httpntlm');
-    
+
+    // additionalConfig may carry axios-only options (e.g. responseType from
+    // downloadFile) that httpntlm/httpreq don't understand — httpreq needs
+    // `binary: true` to return a raw Buffer instead of utf8-stringifying the
+    // response body, otherwise downloaded .docx files come out corrupted.
+    // Never forward `agent`: httpntlm pins its own keep-alive agent across
+    // the NTLM handshake's two round-trips, and a caller-supplied agent
+    // breaks that connection affinity.
+    const { responseType, agent: _ignoredAgent, headers: callerHeaders, ...restConfig } = additionalConfig;
+
     return new Promise((resolve, reject) => {
-      const options = {
+      const options: Record<string, any> = {
         url: url,
         username: credentials.username,
         password: credentials.password,
         workstation: credentials.domain || '',
         domain: credentials.domain || '',
-        ...additionalConfig,
+        headers: {
+          // On-prem SharePoint returns Atom XML by default; without this,
+          // JSON parsing below silently no-ops and callers see an empty
+          // result set instead of an error.
+          Accept: 'application/json;odata=verbose',
+          ...callerHeaders,
+        },
+        ...restConfig,
       };
+
+      if (responseType === 'arraybuffer') {
+        options.binary = true;
+      }
+
+      if (ALLOW_SELF_SIGNED) {
+        options.rejectUnauthorized = false;
+      }
 
       if (method === 'GET') {
         ntlm.get(options, (err: any, res: any) => {

--- a/src/services/SharePointService.ts
+++ b/src/services/SharePointService.ts
@@ -198,6 +198,19 @@ export class SharePointService {
     if (response?.data?.d?.results) {
       return;
     }
+
+    // A path that doesn't exist (e.g. the pasted templates folder itself,
+    // or a subfolder deleted mid-sync) comes back as SharePoint's own REST
+    // error body, not a list — it already carries a specific,
+    // human-readable message ("File Not Found.", "Access is denied.", etc).
+    // Surface that directly instead of falling through to the generic
+    // body-preview dump below, which reads as a raw technical error rather
+    // than something a user can act on.
+    const odataMessage = response?.data?.error?.message?.value;
+    if (typeof odataMessage === 'string' && odataMessage.trim()) {
+      throw new Error(`SharePoint returned an error while fetching ${context}: ${odataMessage.trim()}`);
+    }
+
     const contentType = response?.headers?.['content-type'] || 'unknown';
     const bodyPreview =
       typeof response?.data === 'string' ? response.data.slice(0, 200) : JSON.stringify(response?.data).slice(0, 200);

--- a/src/services/SharePointService.ts
+++ b/src/services/SharePointService.ts
@@ -3,6 +3,13 @@ import https from 'https';
 import logger from '../util/logger';
 import { GraphSharePointService } from './GraphSharePointService';
 import { isTemplateFileName, isWithinMaxTemplateSize, hasZipSignature } from './sharePointFileValidation';
+import {
+  withThrottleRetry,
+  createRetryBudget,
+  RetryBudget,
+  RETRYABLE_STATUSES,
+  REQUEST_TIMEOUT_MS,
+} from './sharePointRetry';
 
 // On-prem SharePoint often sits behind a self-signed / internal-CA certificate.
 // Prefer NODE_EXTRA_CA_CERTS (trusts the internal CA at the Node level, covers
@@ -36,7 +43,65 @@ export interface SharePointFile {
   timeCreated?: string;
   timeLastModified: string;
   length: number;
-  docType?: string; // Detected from parent folder name
+  docType?: string; // Detected from immediate parent folder name — only set when the file has a parent (not at the connected root)
+  relativePath: string; // Path relative to the connected root, e.g. "STD/File.dotx" or just "File.dotx" at the root — the stable per-file identity (recursion permits duplicate basenames)
+}
+
+// A folder the walk couldn't read (permission-denied) and skipped rather
+// than aborting the whole listing over. `relativePath` matches the identity
+// used everywhere else in this feature; `reason` is the human-readable
+// cause (SharePoint's own OData message, or Graph's mapped error message).
+export interface SkippedFolder {
+  relativePath: string;
+  reason: string;
+}
+
+// Result of a recursive template-file listing — `truncated` is set when a
+// safety cap (depth or total file count) was hit before every file could be
+// walked, so callers can surface that honestly instead of silently
+// under-reporting. `skippedFolders` lists folders that were denied and
+// skipped (never the connected root itself — a denied root always aborts
+// the whole listing, since silently reporting "0 files found" there would
+// be indistinguishable from a genuinely empty folder).
+export interface SharePointFileListing {
+  files: SharePointFile[];
+  truncated: boolean;
+  skippedFolders: SkippedFolder[];
+}
+
+// Safety nets against a pathological tree (not real-world limits — a
+// genuine templates folder is rarely more than a couple of levels deep or a
+// few dozen files). Exported so GraphSharePointService's recursive walk
+// applies the identical caps.
+export const MAX_RECURSION_DEPTH = 6;
+export const MAX_RECURSION_FILES = 500;
+// Cap what's serialized into every list/check/sync response — a poorly
+// permissioned library could otherwise have hundreds of denied folders.
+export const MAX_SKIPPED_FOLDERS_RECORDED = 25;
+
+// How many folders' Files+Folders fetches run concurrently during the BFS
+// walk, instead of strictly one at a time. Comfortably under both
+// Microsoft's tested ~60 req/sec/on-prem-web-server ceiling and Graph's
+// ~10 req/sec/user sustained limit — on-prem costs 2 sequential requests
+// per folder, so steady-state in-flight is 4, not 8. Don't raise this
+// without also raising sharePointRetry's DEFAULT_RETRY_BUDGET_MS.
+export const CONCURRENT_FOLDER_FETCHES = 4;
+
+// One BFS queue entry — a folder still to walk. `relativePath` is that
+// folder's own path relative to the connected root ('' at the root
+// itself); `parentName` is undefined only at the root, so files found
+// there correctly get no docType.
+type FolderQueueItem = { folderPath: string; relativePath: string; depth: number; parentName?: string };
+
+// Result of fetching one folder's Files + Folders. `files` is populated
+// even when `skipped` is also set — a folder denied only on its `/Folders`
+// call keeps the files it already found from `/Files`, it just doesn't
+// descend further.
+interface FetchFolderResult {
+  files: SharePointFile[];
+  subfoldersToEnqueue: FolderQueueItem[];
+  skipped?: { relativePath: string; reason: string };
+  depthCapped?: boolean;
 }
 
 // SharePoint configuration interface
@@ -84,7 +149,12 @@ export class SharePointService {
     const sitePath = this.extractSitePath(config.siteUrl);
     // Remove trailing slash from site path
     const cleanSitePath = sitePath.endsWith('/') ? sitePath.slice(0, -1) : sitePath;
-    return [cleanSitePath, config.library, config.folder].filter(Boolean).join('/');
+    const joined = [cleanSitePath, config.library, config.folder].filter(Boolean).join('/');
+    // A root-web site (siteUrl has no path at all, so cleanSitePath is '')
+    // would otherwise produce a path with no leading slash here —
+    // GetFolderByServerRelativeUrl(...) expects a server-relative path,
+    // which always starts with '/'.
+    return joined.startsWith('/') ? joined : `/${joined}`;
   }
 
   /**
@@ -101,11 +171,19 @@ export class SharePointService {
    * POST-only specifically because it also hands back a write-capable form
    * digest that needs CSRF protection — we only need to *read* where the
    * URL sits, so the plain `web` entry point (a normal GET, no new HTTP
-   * method support needed in makeNTLMRequest) does the same job. Both are
-   * reached through the same `_api` request-routing layer, which resolves
-   * the "nearest web" for any URL under the site, not just a site's own
-   * root URL — see "Navigate the SharePoint data structure represented in
-   * the REST service" on Microsoft Learn.
+   * method support needed in makeNTLMRequest) does the same job.
+   *
+   * `_api`'s "nearest web" routing IS reliable when `_api` sits immediately
+   * after a real web's own URL (e.g. a `/sites/x` site), but is NOT reliable
+   * at arbitrary depth past several document-library/folder segments —
+   * confirmed against a real production 500 for exactly that shape (a
+   * root-web site with a deep folder path and no `/sites/...` prefix at
+   * all). Rather than assume the pasted URL's full depth IS the site
+   * boundary, try `_api/web` at the full path first, then walk to
+   * progressively shallower prefixes until one resolves. The bare origin
+   * (a root web, which always exists) is always the last, guaranteed-valid
+   * candidate. This costs nothing extra for the common `/sites/x` case — it
+   * still resolves on the very first, deepest attempt exactly as before.
    */
   async resolveSiteFromUrl(
     pastedUrl: string,
@@ -113,53 +191,82 @@ export class SharePointService {
   ): Promise<{ siteUrl: string; library: string; folder: string }> {
     try {
       const parsedUrl = new URL(pastedUrl);
+      const origin = parsedUrl.origin;
       // Use the URL's own path only — a pasted AllItems.aspx link carries a
       // query string (?web=1&RootFolder=...&FolderCTID=...), and appending
       // /_api/web onto that unstripped would glue our API path onto the end
       // of whatever query param happens to be last, never actually reaching
-      // _api/web. The page path alone is enough for _api/web's "nearest
-      // site" routing to resolve the site boundary. Strip the query string
-      // by taking only the base URL (scheme + origin + path), preserving
-      // the exact encoding of the pasted URL.
+      // _api/web. Derived from the raw pasted string (not `parsedUrl.pathname`,
+      // which the WHATWG URL parser re-percent-encodes — e.g. turning a
+      // literal space into %20) so every candidate preserves the pasted
+      // URL's exact original encoding, unchanged from before this fix.
       const baseUrlString = pastedUrl.split('?')[0];
       const baseUrl = baseUrlString.replace(/\/+$/, '');
-      const apiUrl = `${baseUrl}/_api/web?$select=ServerRelativeUrl`;
+      const pathOnly = baseUrl.startsWith(origin) ? baseUrl.slice(origin.length) : baseUrl.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^/]+/, '');
+      const segments = pathOnly.split('/').filter(Boolean);
+      // Runaway-safety cap on how many candidates we'll try — not a
+      // real-world limit; a genuine folder path is rarely more than a
+      // handful of segments deep.
+      const MAX_CANDIDATE_SEGMENTS = 15;
+      const cappedSegments = segments.slice(0, MAX_CANDIDATE_SEGMENTS);
 
-      logger.info(`Resolving SharePoint site from pasted URL: ${baseUrl}`);
+      let lastResponse: any = null;
+      let lastRequestError: any = null;
 
-      const response = await this.makeNTLMRequest(apiUrl, credentials, 'GET');
-      const serverRelativeUrl = response?.data?.d?.ServerRelativeUrl;
+      for (let depth = cappedSegments.length; depth >= 0; depth--) {
+        const candidatePath = cappedSegments.slice(0, depth).join('/');
+        const candidateBaseUrl = candidatePath ? `${origin}/${candidatePath}` : origin;
+        const apiUrl = `${candidateBaseUrl}/_api/web?$select=ServerRelativeUrl`;
 
-      if (typeof serverRelativeUrl !== 'string') {
-        const contentType = response?.headers?.['content-type'] || 'unknown';
-        const bodyPreview =
-          typeof response?.data === 'string'
-            ? response.data.slice(0, 200)
-            : JSON.stringify(response?.data).slice(0, 200);
-        throw new Error(
-          `Could not resolve a SharePoint site from this URL (content-type: ${contentType}). Body preview: ${bodyPreview}`
-        );
+        logger.info(`Resolving SharePoint site from pasted URL — trying: ${candidateBaseUrl}`);
+
+        let response: any;
+        try {
+          // Deliberately not routed through makeSharePointRequest (no
+          // retry) — up to 15 candidates are tried, and expected-to-fail
+          // probes must stay fast. Still needs its own timeout though: with
+          // no retry wrapper providing one, an untimed candidate here could
+          // stall the whole walk far longer than before this cap existed.
+          response = await this.makeNTLMRequest(apiUrl, credentials, 'GET', { timeout: REQUEST_TIMEOUT_MS });
+        } catch (err) {
+          lastRequestError = err;
+          continue;
+        }
+        lastResponse = response;
+
+        const serverRelativeUrl = response?.data?.d?.ServerRelativeUrl;
+        if (typeof serverRelativeUrl !== 'string') {
+          continue;
+        }
+
+        logger.info(`Resolved SharePoint site at: ${candidateBaseUrl}`);
+
+        // A browsed AllItems.aspx URL (on-prem's equivalent of Online's
+        // ?id=... shape) carries the real target folder in ?RootFolder=...,
+        // not in the page's own path — the page path is just the library's
+        // Forms view. Prefer it when present; fall back to the URL's own
+        // path for a direct folder link that has no RootFolder param. This
+        // operates on the pasted URL and the REAL resolved
+        // serverRelativeUrl — unaffected by which candidate matched.
+        const rootFolderParam = parsedUrl.searchParams.get('RootFolder');
+        const fullPath = rootFolderParam ?? decodeURIComponent(parsedUrl.pathname);
+        const folder = fullPath.startsWith(serverRelativeUrl)
+          ? fullPath.slice(serverRelativeUrl.length).replace(/^\/+/, '')
+          : fullPath.replace(/^\/+/, '');
+
+        // A root-web site resolves serverRelativeUrl to "/" — strip any
+        // trailing slash so every downstream `${siteUrl}/_api/...` call
+        // doesn't end up with a doubled slash (which IIS commonly rejects).
+        // Falls back to the bare origin, never an empty string.
+        const siteUrl = `${origin}${serverRelativeUrl}`.replace(/\/+$/, '') || origin;
+
+        return { siteUrl, library: '', folder };
       }
 
-      // A browsed AllItems.aspx URL (on-prem's equivalent of Online's
-      // ?id=... shape) carries the real target folder in ?RootFolder=...,
-      // not in the page's own path — the page path is just the library's
-      // Forms view. Prefer it when present; fall back to the URL's own path
-      // for a direct folder link that has no RootFolder param.
-      const rootFolderParam = parsedUrl.searchParams.get('RootFolder');
-      const fullPath = rootFolderParam ?? decodeURIComponent(parsedUrl.pathname);
-      // fullPath includes the site's own path prefix (serverRelativeUrl) —
-      // strip it so `folder` is relative to the site, not duplicated when
-      // constructFolderPath re-prepends the site path.
-      const folder = fullPath.startsWith(serverRelativeUrl)
-        ? fullPath.slice(serverRelativeUrl.length).replace(/^\/+/, '')
-        : fullPath.replace(/^\/+/, '');
-
-      return {
-        siteUrl: `${parsedUrl.origin}${serverRelativeUrl}`,
-        library: '',
-        folder,
-      };
+      if (lastRequestError) {
+        throw lastRequestError;
+      }
+      throw new Error(this.describeUnexpectedResponse(lastResponse, 'a SharePoint site for this URL'));
     } catch (error: any) {
       logger.error(`Failed to resolve SharePoint site from URL: ${error.message}`);
       throw new Error(`Failed to resolve SharePoint site from URL: ${error.message}`);
@@ -187,6 +294,56 @@ export class SharePointService {
   }
 
   /**
+   * Builds a diagnostic message for a response that didn't carry what the
+   * caller expected and doesn't match SharePoint's own OData error shape
+   * either (e.g. a redirect to a login/error page, a bare re-challenge, an
+   * HTML error page). Includes `status` and, when present, `location`/
+   * `www-authenticate` — the previous content-type-and-body-only version
+   * couldn't distinguish a redirect from an auth challenge from a genuine
+   * 404/500, since a body-less response leaves both blank regardless of
+   * which actually happened.
+   */
+  private describeUnexpectedResponse(response: any, context: string): string {
+    const status = response?.status ?? 'unknown';
+    const headers = response?.headers || {};
+    const contentType = headers['content-type'] || 'unknown';
+    const location = headers['location'];
+    const wwwAuthenticate = headers['www-authenticate'];
+    const bodyPreview =
+      typeof response?.data === 'string' ? response.data.slice(0, 200) : JSON.stringify(response?.data).slice(0, 200);
+
+    const details = [`status: ${status}`, `content-type: ${contentType}`];
+    if (location) details.push(`location: ${location}`);
+    if (wwwAuthenticate) details.push(`www-authenticate: ${wwwAuthenticate}`);
+
+    return `Unexpected response fetching ${context} (${details.join(', ')}). Body preview: ${bodyPreview}`;
+  }
+
+  /**
+   * True when `response` represents a permission-denied folder — worth
+   * skipping and continuing the walk rather than aborting the whole
+   * listing. Deliberately excludes 401: a 401 means the credentials/token
+   * themselves are invalid, not that this one folder is restricted — every
+   * remaining folder would also 401, so tolerating it would silently turn a
+   * clean auth failure into "0 files found, N folders skipped". Callers
+   * must additionally gate on `depth > 0` — a denied connected root must
+   * always abort (see SharePointFileListing's doc comment).
+   */
+  private accessDeniedReason(response: any): string | null {
+    if (!response) return null;
+    const status = response.status;
+    if (status === 401) return null;
+    if (status === 403) {
+      return response?.data?.error?.message?.value || 'Access is denied.';
+    }
+    const odataMessage = response?.data?.error?.message?.value;
+    if (typeof odataMessage === 'string' && /access\s+(is\s+)?denied|do not have permission|unauthorized/i.test(odataMessage)) {
+      return odataMessage;
+    }
+    return null;
+  }
+
+  /**
    * Guards against a response that isn't the expected SharePoint REST JSON
    * list shape ({ d: { results: [...] } }). Previously an unrecognised
    * response (e.g. Atom XML returned when the NTLM request didn't send an
@@ -211,12 +368,7 @@ export class SharePointService {
       throw new Error(`SharePoint returned an error while fetching ${context}: ${odataMessage.trim()}`);
     }
 
-    const contentType = response?.headers?.['content-type'] || 'unknown';
-    const bodyPreview =
-      typeof response?.data === 'string' ? response.data.slice(0, 200) : JSON.stringify(response?.data).slice(0, 200);
-    throw new Error(
-      `Unexpected response fetching ${context} (content-type: ${contentType}). Body preview: ${bodyPreview}`
-    );
+    throw new Error(this.describeUnexpectedResponse(response, context));
   }
 
   /**
@@ -254,7 +406,9 @@ export class SharePointService {
 
       logger.info(`Testing SharePoint connection to: ${apiUrl}`);
 
-      const response = await this.makeNTLMRequest(apiUrl, credentials, 'GET');
+      // Not routed through makeSharePointRequest (a single user-initiated
+      // probe shouldn't retry), but still needs its own timeout.
+      const response = await this.makeNTLMRequest(apiUrl, credentials, 'GET', { timeout: REQUEST_TIMEOUT_MS });
 
       if (response.status === 200) {
         return {
@@ -277,14 +431,27 @@ export class SharePointService {
   }
 
   /**
-   * Lists all Word template files (.docx, .dotx) from a SharePoint folder and its subfolders
-   * Automatically detects docType from subfolder names
-   * Supports both NTLM (on-premise) and OAuth (SharePoint Online)
+   * Lists all Word template files (.docx, .dotx) from a SharePoint folder,
+   * recursively — including files sitting directly at the connected root
+   * (a genuinely flat folder, no per-doc-type subfolders at all) and files
+   * nested more than one level deep. SharePoint REST's `/Folders` and
+   * `/Files` are both strictly one-level (there's no native recursive-list
+   * GET endpoint — the recursive CAML `GetItems` option is POST-only and
+   * needs a form digest, out of reach of the current NTLM GET-only
+   * transport), so this walks the tree itself, reusing the same pair of
+   * one-level calls at every folder. `docType` is only populated when a
+   * file's immediate parent folder is not the connected root — same
+   * auto-detection convention as before, just no longer limited to depth 1.
+   * `truncated` is set if the depth or file-count safety cap was hit before
+   * the whole tree could be walked, so a pathological folder tree degrades
+   * to "list what we found, flagged incomplete" rather than either hanging
+   * or silently dropping files.
+   * Supports both NTLM (on-premise) and OAuth (SharePoint Online).
    */
   async listTemplateFiles(
     config: SharePointConfig,
     credentials: SharePointCredentials | SharePointOAuthToken
-  ): Promise<SharePointFile[]> {
+  ): Promise<SharePointFileListing> {
     try {
       const isOnline = this.isSharePointOnline(config.siteUrl);
       const isOAuth = 'accessToken' in credentials;
@@ -295,72 +462,211 @@ export class SharePointService {
         return await this.graphService.listTemplateFiles(config.siteUrl, credentials);
       }
 
-      const folderPath = this.constructFolderPath(config);
-
-      // First, get list of subfolders
-      const foldersApiUrl = `${config.siteUrl}/_api/web/GetFolderByServerRelativeUrl('${this.toServerRelativeUrlLiteral(folderPath)}')/Folders`;
-      
-      logger.info(`Fetching subfolders from SharePoint: ${foldersApiUrl} (${isOAuth ? 'OAuth' : 'NTLM'})`);
-      
-      const foldersResponse = await this.makeSharePointRequest(foldersApiUrl, credentials, 'GET');
-      this.assertJsonListResponse(foldersResponse, 'subfolders');
-
+      const rootFolderPath = this.constructFolderPath(config);
       const allTemplateFiles: SharePointFile[] = [];
-      const subfolders = foldersResponse.data.d.results;
+      let truncated = false;
+      // Shared across every request this walk makes — see sharePointRetry.ts.
+      const retryBudget = createRetryBudget();
+      const skippedFolders: SkippedFolder[] = [];
+      let totalSkippedFolders = 0;
 
-      logger.info(`Found ${subfolders.length} subfolders in ${folderPath}`);
+      const queue: FolderQueueItem[] = [{ folderPath: rootFolderPath, relativePath: '', depth: 0 }];
 
-      // For each subfolder, get the files
-      for (const subfolder of subfolders) {
-        const subfolderName = subfolder.Name;
-        const subfolderPath = subfolder.ServerRelativeUrl;
-
-        // Skip system folders
-        if (subfolderName.startsWith('_') || subfolderName.startsWith('.')) {
-          continue;
+      // Records a denied folder and decides whether the walk should keep
+      // going (skip-and-continue) or abort entirely. `depth > 0` gates
+      // tolerance — a denied connected root always aborts, since silently
+      // returning "0 files found" there is indistinguishable from a
+      // genuinely empty folder rather than a permissions problem.
+      const recordSkippedFolder = (relPath: string, reason: string) => {
+        totalSkippedFolders += 1;
+        if (skippedFolders.length < MAX_SKIPPED_FOLDERS_RECORDED) {
+          skippedFolders.push({ relativePath: relPath, reason });
         }
+      };
 
-        const filesApiUrl = `${config.siteUrl}/_api/web/GetFolderByServerRelativeUrl('${this.toServerRelativeUrlLiteral(subfolderPath)}')/Files`;
+      // Batch fetches (I/O only — CONCURRENT_FOLDER_FETCHES at a time), but
+      // accumulate results strictly in queue order, exactly as the fully
+      // sequential walk used to. This keeps `relativePath`/`docType`
+      // derivation and the truncation cutoff bit-identical to before —
+      // both are derived per-entry from the queue item, never from
+      // wall-clock timing, and accumulation only ever reads already-
+      // resolved results in order. One accepted cost: a folder's `/Folders`
+      // is now always fetched even in the folder where the 500-file cap
+      // gets hit (the old code could sometimes skip it — see
+      // fetchFolder's doc comment).
+      while (queue.length > 0 && !truncated) {
+        const batch = queue.splice(0, CONCURRENT_FOLDER_FETCHES);
+        const results = await Promise.all(
+          batch.map((item) => this.fetchFolder(config, credentials, isOAuth, item, retryBudget))
+        );
 
-        logger.info(`Fetching files from subfolder: ${subfolderName}`);
+        for (const result of results) {
+          if (truncated) break;
 
-        const filesResponse = await this.makeSharePointRequest(filesApiUrl, credentials, 'GET');
-        this.assertJsonListResponse(filesResponse, `files in subfolder "${subfolderName}"`);
-
-        const files = filesResponse.data.d.results;
-
-        // Filter for Word template files (excludes ~$ Office lock files and oversized files)
-        const templateFiles = files.filter((file: any) => {
-          if (!isTemplateFileName(file.Name)) return false;
-          if (!isWithinMaxTemplateSize(Number(file.Length))) {
-            logger.warn(`Skipping SharePoint file "${file.Name}" — size ${file.Length} bytes exceeds the sync limit`);
-            return false;
+          for (const file of result.files) {
+            if (allTemplateFiles.length >= MAX_RECURSION_FILES) {
+              truncated = true;
+              break;
+            }
+            allTemplateFiles.push(file);
           }
-          return true;
-        });
+          if (truncated) break;
 
-        // Add files with docType from subfolder name
-        templateFiles.forEach((file: any) => {
-          allTemplateFiles.push({
-            name: file.Name,
-            serverRelativeUrl: file.ServerRelativeUrl,
-            timeCreated: file.TimeCreated,
-            timeLastModified: file.TimeLastModified,
-            length: file.Length,
-            docType: subfolderName, // Subfolder name becomes the docType
-          });
-        });
-
-        logger.info(`Found ${templateFiles.length} template files in ${subfolderName}`);
+          if (result.skipped) {
+            recordSkippedFolder(result.skipped.relativePath, result.skipped.reason);
+            continue;
+          }
+          if (result.depthCapped) {
+            truncated = true;
+            continue;
+          }
+          queue.push(...result.subfoldersToEnqueue);
+        }
       }
 
-      logger.info(`Total template files found: ${allTemplateFiles.length}`);
+      // If capped, note the true total rather than silently under-reporting
+      // how many folders were actually denied.
+      if (totalSkippedFolders > skippedFolders.length) {
+        skippedFolders.push({
+          relativePath: '',
+          reason: `…and ${totalSkippedFolders - skippedFolders.length} more folder(s) were also skipped`,
+        });
+      }
 
-      return allTemplateFiles;
+      logger.info(
+        `Total template files found: ${allTemplateFiles.length}${truncated ? ' (truncated)' : ''}${
+          totalSkippedFolders ? `, ${totalSkippedFolders} folder(s) skipped (access denied)` : ''
+        }`
+      );
+
+      return { files: allTemplateFiles, truncated, skippedFolders };
     } catch (error: any) {
       logger.error(`Failed to list SharePoint files: ${error.message}`);
       throw new Error(`Failed to list SharePoint files: ${error.message}`);
     }
+  }
+
+  /**
+   * Fetches one folder's Files then Folders — the I/O unit `listTemplateFiles`
+   * runs CONCURRENT_FOLDER_FETCHES of at a time. Pure I/O: no shared state is
+   * read or written here (the running file count, truncation flag, and
+   * skippedFolders list all live in the caller and are updated only once
+   * every promise in a batch has resolved, in queue order) — that's what
+   * keeps concurrent fetching from changing which files end up in the
+   * result or where the truncation cutoff falls.
+   *
+   * Always fetches `/Folders` even when depth/skip logic will discard the
+   * result — unlike the old strictly-sequential walk, which could skip that
+   * call once the file-count cap was already hit inside this same folder's
+   * `/Files` response. That short-circuit isn't available per-item inside a
+   * concurrent batch (the running total isn't known until every promise in
+   * the batch settles), so a folder that happens to be the one where the
+   * cap is hit costs one extra, unused request. Accepted — see the plan
+   * this was implemented from.
+   */
+  private async fetchFolder(
+    config: SharePointConfig,
+    credentials: SharePointCredentials | SharePointOAuthToken,
+    isOAuth: boolean,
+    item: FolderQueueItem,
+    retryBudget: RetryBudget
+  ): Promise<FetchFolderResult> {
+    const { folderPath, relativePath, depth, parentName } = item;
+
+    const filesApiUrl = `${config.siteUrl}/_api/web/GetFolderByServerRelativeUrl('${this.toServerRelativeUrlLiteral(folderPath)}')/Files`;
+    logger.info(`Fetching files from SharePoint folder: ${folderPath} (${isOAuth ? 'OAuth' : 'NTLM'})`);
+
+    let filesResponse: any;
+    try {
+      filesResponse = await this.makeSharePointRequest(filesApiUrl, credentials, 'GET', {}, retryBudget);
+    } catch (err: any) {
+      const status = err?.response?.status ?? err?.status;
+      if (status === 403 && depth > 0) {
+        logger.warn(`Skipping inaccessible folder "${folderPath}": ${err.message}`);
+        return {
+          files: [],
+          subfoldersToEnqueue: [],
+          skipped: { relativePath, reason: err.message || 'Access is denied.' },
+        };
+      }
+      throw err;
+    }
+
+    const filesDeniedReason = this.accessDeniedReason(filesResponse);
+    if (filesDeniedReason && depth > 0) {
+      logger.warn(`Skipping inaccessible folder "${folderPath}": ${filesDeniedReason}`);
+      return { files: [], subfoldersToEnqueue: [], skipped: { relativePath, reason: filesDeniedReason } };
+    }
+
+    this.assertJsonListResponse(filesResponse, `files in "${folderPath}"`);
+    const rawFiles = filesResponse.data.d.results;
+
+    // Filter for Word template files (excludes ~$ Office lock files and oversized files)
+    const templateFiles = rawFiles.filter((file: any) => {
+      if (!isTemplateFileName(file.Name)) return false;
+      if (!isWithinMaxTemplateSize(Number(file.Length))) {
+        logger.warn(`Skipping SharePoint file "${file.Name}" — size ${file.Length} bytes exceeds the sync limit`);
+        return false;
+      }
+      return true;
+    });
+
+    const files: SharePointFile[] = templateFiles.map((file: any) => ({
+      name: file.Name,
+      serverRelativeUrl: file.ServerRelativeUrl,
+      timeCreated: file.TimeCreated,
+      timeLastModified: file.TimeLastModified,
+      length: file.Length,
+      docType: parentName,
+      relativePath: relativePath ? `${relativePath}/${file.Name}` : file.Name,
+    }));
+
+    logger.info(`Found ${templateFiles.length} template files in "${folderPath || '(root)'}"`);
+
+    // Descend into subfolders, unless the depth cap is already reached.
+    const foldersApiUrl = `${config.siteUrl}/_api/web/GetFolderByServerRelativeUrl('${this.toServerRelativeUrlLiteral(folderPath)}')/Folders`;
+
+    let foldersResponse: any;
+    try {
+      foldersResponse = await this.makeSharePointRequest(foldersApiUrl, credentials, 'GET', {}, retryBudget);
+    } catch (err: any) {
+      const status = err?.response?.status ?? err?.status;
+      if (status === 403 && depth > 0) {
+        // The files already found in this folder are kept — only
+        // descending further is blocked.
+        logger.warn(`Skipping subfolders of inaccessible folder "${folderPath}": ${err.message}`);
+        return { files, subfoldersToEnqueue: [], skipped: { relativePath, reason: err.message || 'Access is denied.' } };
+      }
+      throw err;
+    }
+
+    const foldersDeniedReason = this.accessDeniedReason(foldersResponse);
+    if (foldersDeniedReason && depth > 0) {
+      logger.warn(`Skipping subfolders of inaccessible folder "${folderPath}": ${foldersDeniedReason}`);
+      return { files, subfoldersToEnqueue: [], skipped: { relativePath, reason: foldersDeniedReason } };
+    }
+
+    this.assertJsonListResponse(foldersResponse, `subfolders in "${folderPath}"`);
+    const subfolders = foldersResponse.data.d.results.filter(
+      (sf: any) => !sf.Name.startsWith('_') && !sf.Name.startsWith('.')
+    );
+
+    if (depth >= MAX_RECURSION_DEPTH) {
+      if (subfolders.length > 0) {
+        logger.warn(`Hit max recursion depth (${MAX_RECURSION_DEPTH}) at "${folderPath}" with ${subfolders.length} unexplored subfolder(s)`);
+        return { files, subfoldersToEnqueue: [], depthCapped: true };
+      }
+      return { files, subfoldersToEnqueue: [] };
+    }
+
+    const subfoldersToEnqueue: FolderQueueItem[] = subfolders.map((subfolder: any) => ({
+      folderPath: subfolder.ServerRelativeUrl,
+      relativePath: relativePath ? `${relativePath}/${subfolder.Name}` : subfolder.Name,
+      depth: depth + 1,
+      parentName: subfolder.Name,
+    }));
+
+    return { files, subfoldersToEnqueue };
   }
 
   /**
@@ -409,21 +715,47 @@ export class SharePointService {
   }
 
   /**
-   * Makes a SharePoint API request (supports both NTLM and OAuth)
+   * Makes a SharePoint API request (supports both NTLM and OAuth). This is
+   * the single choke point both `listTemplateFiles` and `downloadFile` go
+   * through, so it's where throttle-aware retry and a request timeout are
+   * applied — not inside `makeNTLMRequest`/`makeOAuthRequest` individually.
+   * Deliberately NOT used by `testConnection`/`resolveSiteFromUrl`, which
+   * call `makeNTLMRequest` directly: those issue candidate requests they
+   * expect to fail (resolveSiteFromUrl tries up to 15 URL depths) and must
+   * stay fast-fail rather than retrying each expected failure.
+   *
+   * `retryBudget`, when passed, is shared across every request in one
+   * `listTemplateFiles` walk — see sharePointRetry.ts's doc comment for why
+   * that matters once folder fetches run concurrently.
    */
   private async makeSharePointRequest(
     url: string,
     auth: SharePointCredentials | SharePointOAuthToken,
     method: string = 'GET',
-    additionalConfig: any = {}
+    additionalConfig: any = {},
+    retryBudget?: RetryBudget
   ): Promise<any> {
     const isOAuth = 'accessToken' in auth;
-    
-    if (isOAuth) {
-      return this.makeOAuthRequest(url, auth as SharePointOAuthToken, method, additionalConfig);
-    } else {
-      return this.makeNTLMRequest(url, auth as SharePointCredentials, method, additionalConfig);
-    }
+    const configWithTimeout = { timeout: REQUEST_TIMEOUT_MS, ...additionalConfig };
+
+    return withThrottleRetry(
+      () =>
+        isOAuth
+          ? this.makeOAuthRequest(url, auth as SharePointOAuthToken, method, configWithTimeout)
+          : this.makeNTLMRequest(url, auth as SharePointCredentials, method, configWithTimeout),
+      (outcome) => {
+        // NTLM resolves normally even on non-2xx (status lives on the
+        // resolved value); OAuth/axios throws on non-2xx (status lives on
+        // the thrown error's `.response`). Check both shapes.
+        const status = outcome.value?.status ?? outcome.error?.response?.status;
+        const headers = outcome.value?.headers ?? outcome.error?.response?.headers;
+        return {
+          retryable: RETRYABLE_STATUSES.includes(status),
+          retryAfter: headers?.['retry-after'],
+        };
+      },
+      { budget: retryBudget, label: url }
+    );
   }
 
   /**

--- a/src/services/auth/IdTokenValidator.ts
+++ b/src/services/auth/IdTokenValidator.ts
@@ -1,0 +1,27 @@
+// MSAL already validates signature, issuer, and expiry. This adds the two
+// checks specific to this app's own transaction/config: nonce must match
+// what this app generated for this sign-in attempt (anti-replay), and the
+// tenant must match the single tenant this app is registered against.
+export interface IdTokenClaimsSubset {
+  nonce?: string;
+  tid?: string;
+  aud?: string;
+}
+
+export interface ExpectedIdTokenClaims {
+  nonce: string;
+  tenantId: string;
+  clientId: string;
+}
+
+export function assertIdTokenClaims(claims: IdTokenClaimsSubset, expected: ExpectedIdTokenClaims): void {
+  if (!claims.nonce || claims.nonce !== expected.nonce) {
+    throw new Error('ID token nonce mismatch');
+  }
+  if (!claims.tid || claims.tid !== expected.tenantId) {
+    throw new Error('ID token tenant mismatch');
+  }
+  if (!claims.aud || claims.aud !== expected.clientId) {
+    throw new Error('ID token audience mismatch');
+  }
+}

--- a/src/services/auth/MongoTokenCachePlugin.ts
+++ b/src/services/auth/MongoTokenCachePlugin.ts
@@ -1,0 +1,89 @@
+// Implements MSAL Node's distributed-cache extension points against the
+// existing Mongoose connection. `MongoCacheClient` is the get/set half
+// (ICacheClient); `HomeAccountPartitionManager` tells
+// DistributedCachePlugin which partition to read/write (IPartitionManager).
+// beforeCacheAccess calls getKey() to decide what to load; afterCacheAccess
+// calls extractKey() on the newly-written account to decide what to save —
+// how a fresh redemption (homeAccountId not yet known) still lands in the
+// right partition once MSAL discovers it.
+import { ICacheClient, IPartitionManager, DistributedCachePlugin } from '@azure/msal-node';
+import { MsalTokenCache } from '../../models/MsalTokenCache';
+import { encryptCacheBlob, decryptCacheBlob } from '../../util/tokenCacheCipher';
+import logger from '../../util/logger';
+
+// ~90 days, matching Entra's typical refresh-token inactivity window — a
+// cache row that hasn't been written to in that long is for a user who
+// hasn't used the app in 90 days, at which point re-auth is expected.
+const CACHE_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+// Structural subset of MSAL's internal AccountEntity — only the field this
+// plugin actually reads. Avoids a compile-time dependency on
+// @azure/msal-common's internal (not part of docgen-api-gate's own
+// package.json) module layout for a single field read.
+interface AccountEntityLike {
+  homeAccountId: string;
+}
+
+export class MongoCacheClient implements ICacheClient {
+  async get(key: string): Promise<string> {
+    if (!key) return '';
+    const doc = await MsalTokenCache.findOne({ homeAccountId: key });
+    if (!doc) return '';
+    try {
+      return decryptCacheBlob({
+        ciphertext: doc.ciphertext,
+        iv: doc.iv,
+        authTag: doc.authTag,
+        keyVersion: doc.keyVersion,
+      });
+    } catch (error) {
+      // Corrupted blob or rotated-out key fails closed as a cache miss, not
+      // a 500 — worst case is a forced re-sign-in, never a security hole.
+      logger.error(`Failed to decrypt MSAL token cache for a session partition: ${error.message}`);
+      return '';
+    }
+  }
+
+  async set(key: string, value: string): Promise<string> {
+    if (!key) return value;
+    const blob = encryptCacheBlob(value);
+    await MsalTokenCache.findOneAndUpdate(
+      { homeAccountId: key },
+      {
+        $set: {
+          ciphertext: blob.ciphertext,
+          iv: blob.iv,
+          authTag: blob.authTag,
+          keyVersion: blob.keyVersion,
+          expiresAt: new Date(Date.now() + CACHE_TTL_MS),
+        },
+      },
+      { upsert: true }
+    );
+    return value;
+  }
+}
+
+export class HomeAccountPartitionManager implements IPartitionManager {
+  // `knownHomeAccountId` is undefined during a fresh code redemption, before
+  // MSAL creates the account entity — getKey() returning '' is correct
+  // there, since nothing exists yet to load.
+  constructor(private readonly knownHomeAccountId?: string) {}
+
+  async getKey(): Promise<string> {
+    return this.knownHomeAccountId ?? '';
+  }
+
+  async extractKey(accountEntity: AccountEntityLike): Promise<string> {
+    return accountEntity.homeAccountId;
+  }
+}
+
+export function createPartitionedCachePlugin(homeAccountId?: string): {
+  cachePlugin: DistributedCachePlugin;
+  partitionManager: HomeAccountPartitionManager;
+} {
+  const partitionManager = new HomeAccountPartitionManager(homeAccountId);
+  const cachePlugin = new DistributedCachePlugin(new MongoCacheClient(), partitionManager);
+  return { cachePlugin, partitionManager };
+}

--- a/src/services/auth/MsalClientService.ts
+++ b/src/services/auth/MsalClientService.ts
@@ -1,0 +1,111 @@
+// The only module that constructs a ConfidentialClientApplication. A fresh
+// CCA is built per operation (cheap — this is MSAL Node's own documented
+// distributed-cache pattern), scoped to a cache-plugin partition that
+// either targets a known homeAccountId (silent refresh) or none yet (a
+// fresh code redemption, before the resulting account is known).
+import { createHash } from 'crypto';
+import {
+  ConfidentialClientApplication,
+  AuthenticationResult,
+  InteractionRequiredAuthError,
+} from '@azure/msal-node';
+import { getAuthConfig } from '../../util/authConfig';
+import { createPartitionedCachePlugin } from './MongoTokenCachePlugin';
+
+// openid/profile/offline_access are the standard OIDC scopes (ID token +
+// refresh token issuance); Files.Read.All is the only Graph permission this
+// app requests. Deliberately no User.Read — the ID token's own claims
+// already supply displayName/UPN.
+const AUTH_CODE_SCOPES = ['openid', 'profile', 'offline_access', 'https://graph.microsoft.com/Files.Read.All'];
+// Silent (cache-refresh) requests only ever re-request the resource scope
+// — openid/profile/offline_access aren't valid to pass to acquireTokenSilent,
+// they're implicit in the cached refresh token.
+const SILENT_SCOPES = ['https://graph.microsoft.com/Files.Read.All'];
+
+export type GraphTokenProvider = () => Promise<string>;
+
+export class ReauthRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ReauthRequiredError';
+  }
+}
+
+function buildConfidentialClientApplication(homeAccountId?: string): ConfidentialClientApplication {
+  const { clientId, tenantId, clientSecret } = getAuthConfig();
+  const { cachePlugin } = createPartitionedCachePlugin(homeAccountId);
+  return new ConfidentialClientApplication({
+    auth: {
+      clientId,
+      authority: `https://login.microsoftonline.com/${tenantId}`,
+      clientSecret,
+    },
+    cache: { cachePlugin },
+  });
+}
+
+function computeCodeChallenge(codeVerifier: string): string {
+  return createHash('sha256').update(codeVerifier).digest('base64url');
+}
+
+export interface BuildAuthCodeUrlInput {
+  state: string;
+  nonce: string;
+  codeVerifier: string;
+}
+
+export async function buildAuthCodeUrl(input: BuildAuthCodeUrlInput): Promise<string> {
+  const { redirectUri } = getAuthConfig();
+  const cca = buildConfidentialClientApplication();
+  return cca.getAuthCodeUrl({
+    scopes: AUTH_CODE_SCOPES,
+    redirectUri,
+    state: input.state,
+    nonce: input.nonce,
+    codeChallenge: computeCodeChallenge(input.codeVerifier),
+    codeChallengeMethod: 'S256',
+  });
+}
+
+export interface RedeemAuthCodeInput {
+  code: string;
+  codeVerifier: string;
+  state?: string;
+}
+
+export async function redeemAuthCode(input: RedeemAuthCodeInput): Promise<AuthenticationResult> {
+  const { redirectUri } = getAuthConfig();
+  // No known homeAccountId yet — this is exactly the scenario
+  // HomeAccountPartitionManager's getKey()/extractKey() split exists for.
+  const cca = buildConfidentialClientApplication();
+  return cca.acquireTokenByCode({
+    scopes: AUTH_CODE_SCOPES,
+    redirectUri,
+    code: input.code,
+    codeVerifier: input.codeVerifier,
+    state: input.state,
+  });
+}
+
+// Returns a closure that calls acquireTokenSilent on EVERY invocation, so a
+// caller looping over many downloads always has a fresh token even if the
+// loop outlives a 60-90 minute access token. MSAL caches the underlying
+// network call itself while the token is still valid, so this is cheap.
+export function createTokenProvider(homeAccountId: string): GraphTokenProvider {
+  return async () => {
+    const cca = buildConfidentialClientApplication(homeAccountId);
+    const account = await cca.getTokenCache().getAccountByHomeId(homeAccountId);
+    if (!account) {
+      throw new ReauthRequiredError('No cached Microsoft sign-in found for this session');
+    }
+    try {
+      const result = await cca.acquireTokenSilent({ account, scopes: SILENT_SCOPES });
+      return result.accessToken;
+    } catch (error: any) {
+      if (error instanceof InteractionRequiredAuthError) {
+        throw new ReauthRequiredError(error.message);
+      }
+      throw error;
+    }
+  };
+}

--- a/src/services/auth/OAuthTransactionService.ts
+++ b/src/services/auth/OAuthTransactionService.ts
@@ -1,0 +1,57 @@
+// Creates and consumes the short-lived PKCE/state transaction record.
+// consumeTransaction's findOneAndDelete makes state replay structurally
+// impossible, not just check-then-delete racy.
+import { OAuthTransaction } from '../../models/OAuthTransaction';
+import { newOpaqueToken } from '../../util/randomTokens';
+
+const TRANSACTION_TTL_MS = 10 * 60 * 1000;
+
+export type Transport = 'cookie' | 'bearer';
+
+export interface CreateTransactionInput {
+  openerOrigin: string;
+  transport: Transport;
+}
+
+export interface TransactionRecord {
+  state: string;
+  codeVerifier: string;
+  nonce: string;
+  openerOrigin: string;
+  transport: Transport;
+}
+
+export async function createTransaction(input: CreateTransactionInput): Promise<TransactionRecord> {
+  const state = newOpaqueToken();
+  const codeVerifier = newOpaqueToken(); // 32 bytes -> 43 chars, within RFC 7636's PKCE verifier range
+  const nonce = newOpaqueToken();
+
+  await OAuthTransaction.create({
+    state,
+    codeVerifier,
+    nonce,
+    openerOrigin: input.openerOrigin,
+    transport: input.transport,
+    expiresAt: new Date(Date.now() + TRANSACTION_TTL_MS),
+  });
+
+  return { state, codeVerifier, nonce, openerOrigin: input.openerOrigin, transport: input.transport };
+}
+
+// findOneAndDelete is atomic at the database level, so this is single-use
+// even under concurrent calls with the same `state`.
+export async function consumeTransaction(state: string): Promise<TransactionRecord | null> {
+  const doc = await OAuthTransaction.findOneAndDelete({
+    state,
+    expiresAt: { $gt: new Date() },
+  });
+  if (!doc) return null;
+
+  return {
+    state: doc.state,
+    codeVerifier: doc.codeVerifier,
+    nonce: doc.nonce,
+    openerOrigin: doc.openerOrigin,
+    transport: doc.transport as Transport,
+  };
+}

--- a/src/services/auth/SessionService.ts
+++ b/src/services/auth/SessionService.ts
@@ -1,0 +1,135 @@
+// Session lifecycle for both transports (cookie and bearer-handle), plus
+// CSRF token issuance — see the models' own doc comments for why only
+// hashes are ever persisted for the long-lived session/CSRF tokens.
+import { AuthSession } from '../../models/AuthSession';
+import { SessionHandleCode } from '../../models/SessionHandleCode';
+import { MsalTokenCache } from '../../models/MsalTokenCache';
+import { newOpaqueToken, hashToken, timingSafeEqualStr } from '../../util/randomTokens';
+import { encryptCacheBlob, decryptCacheBlob } from '../../util/tokenCacheCipher';
+
+const IDLE_TTL_MS = 60 * 60 * 1000; // 60 min rolling
+const ABSOLUTE_TTL_MS = 8 * 60 * 60 * 1000; // 8h hard cap
+const HANDLE_CODE_TTL_MS = 60 * 1000; // 60s, single-use
+
+export type Transport = 'cookie' | 'bearer';
+
+export interface CreateSessionInput {
+  homeAccountId: string;
+  transport: Transport;
+  displayName?: string;
+  userPrincipalName?: string;
+  tenantId?: string;
+}
+
+export interface SessionTokens {
+  sessionToken: string; // raw — caller sets this as the cookie value or bearer credential
+  csrfToken: string; // raw — caller sets this as the CSRF cookie/response value
+}
+
+export async function createSession(input: CreateSessionInput): Promise<SessionTokens> {
+  const sessionToken = newOpaqueToken();
+  const csrfToken = newOpaqueToken();
+  const now = new Date();
+
+  await AuthSession.create({
+    sessionTokenHash: hashToken(sessionToken),
+    homeAccountId: input.homeAccountId,
+    transport: input.transport,
+    csrfTokenHash: hashToken(csrfToken),
+    displayName: input.displayName,
+    userPrincipalName: input.userPrincipalName,
+    tenantId: input.tenantId,
+    lastSeenAt: now,
+    idleExpiresAt: new Date(now.getTime() + IDLE_TTL_MS),
+    absoluteExpiresAt: new Date(now.getTime() + ABSOLUTE_TTL_MS),
+  });
+
+  return { sessionToken, csrfToken };
+}
+
+export interface ResolvedSession {
+  sessionId: string;
+  homeAccountId: string;
+  transport: Transport;
+  displayName?: string;
+  userPrincipalName?: string;
+}
+
+// Resolves a raw session token to its session record, sliding the idle
+// expiry forward on every successful resolution. Absolute expiry is never
+// extended, regardless of activity.
+export async function resolveSession(rawToken: string): Promise<ResolvedSession | null> {
+  if (!rawToken) return null;
+  const now = new Date();
+
+  const doc = await AuthSession.findOneAndUpdate(
+    {
+      sessionTokenHash: hashToken(rawToken),
+      idleExpiresAt: { $gt: now },
+      absoluteExpiresAt: { $gt: now },
+    },
+    { $set: { lastSeenAt: now, idleExpiresAt: new Date(now.getTime() + IDLE_TTL_MS) } },
+    { new: true }
+  );
+  if (!doc) return null;
+
+  return {
+    sessionId: String(doc._id),
+    homeAccountId: doc.homeAccountId,
+    transport: doc.transport as Transport,
+    displayName: doc.displayName,
+    userPrincipalName: doc.userPrincipalName,
+  };
+}
+
+// Full sign-out: destroys the session record AND the cached MSAL tokens
+// for that user — deleting the cookie/handle alone is not logout, since a
+// still-cached refresh token would let a new session be silently minted
+// for the same account otherwise.
+export async function revokeSession(rawToken: string): Promise<void> {
+  const doc = await AuthSession.findOneAndDelete({ sessionTokenHash: hashToken(rawToken) });
+  if (doc) {
+    await MsalTokenCache.deleteOne({ homeAccountId: doc.homeAccountId });
+  }
+}
+
+export async function verifyCsrf(rawSessionToken: string, csrfTokenFromRequest: string): Promise<boolean> {
+  const doc = await AuthSession.findOne({ sessionTokenHash: hashToken(rawSessionToken) });
+  if (!doc) return false;
+  return timingSafeEqualStr(hashToken(csrfTokenFromRequest), doc.csrfTokenHash);
+}
+
+// Mints a one-time handle code carrying the raw session token, encrypted at
+// rest for the ~60 seconds this row exists (see SessionHandleCode — the
+// only place the raw token can safely cross the popup->iframe boundary).
+export async function issueHandleCode(rawSessionToken: string): Promise<string> {
+  const code = newOpaqueToken();
+  const blob = encryptCacheBlob(rawSessionToken);
+  await SessionHandleCode.create({
+    codeHash: hashToken(code),
+    sessionTokenCiphertext: blob.ciphertext,
+    sessionTokenIv: blob.iv,
+    sessionTokenAuthTag: blob.authTag,
+    sessionTokenKeyVersion: blob.keyVersion,
+    expiresAt: new Date(Date.now() + HANDLE_CODE_TTL_MS),
+  });
+  return code;
+}
+
+// Single-use by construction (findOneAndDelete) — a replayed handle code
+// finds nothing, exactly like OAuthTransaction's state consumption.
+export async function consumeHandleCode(code: string): Promise<{ sessionToken: string } | null> {
+  const doc = await SessionHandleCode.findOneAndDelete({
+    codeHash: hashToken(code),
+    expiresAt: { $gt: new Date() },
+  });
+  if (!doc) return null;
+
+  const sessionToken = decryptCacheBlob({
+    ciphertext: doc.sessionTokenCiphertext,
+    iv: doc.sessionTokenIv,
+    authTag: doc.sessionTokenAuthTag,
+    keyVersion: doc.sessionTokenKeyVersion,
+  });
+  return { sessionToken };
+}

--- a/src/services/sharePointFileValidation.ts
+++ b/src/services/sharePointFileValidation.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared "is this actually a usable template file" checks for both the
+ * on-prem (SharePointService) and Online/Graph (GraphSharePointService)
+ * listing paths — kept in one place so the two don't drift.
+ */
+
+// Nothing today bounded how large a "template" sync would attempt to pull
+// down; a mispointed folder (or a large attachment sitting in it) would be
+// downloaded in full with no limit. 50MB matches the proven default used by
+// a sibling project's Graph-ingestion implementation for the same problem.
+export const MAX_TEMPLATE_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+
+// .docx/.dotx (Office Open XML) files are ZIP archives — Open Packaging
+// Conventions packages, per ECMA-376 / ISO-IEC 29500-2. A file that doesn't
+// start with the ZIP local-file-header signature cannot be a valid Office
+// document regardless of its extension or claimed mimetype.
+const ZIP_SIGNATURE = Buffer.from([0x50, 0x4b, 0x03, 0x04]); // 'PK\x03\x04'
+
+/**
+ * True if a file name looks like an actual Word template we should sync —
+ * i.e. a .docx/.dotx that isn't one of Office's own `~$...` lock/temp files.
+ * (Word creates these while a document is open; they end in the same
+ * extension as the real file, so a naive extension-only filter picks them
+ * up as "templates".)
+ */
+export function isTemplateFileName(name: string): boolean {
+  if (!name || name.startsWith('~$')) return false;
+  const lower = name.toLowerCase();
+  return lower.endsWith('.docx') || lower.endsWith('.dotx');
+}
+
+/** True if `size` (bytes) is within the sync's size ceiling. */
+export function isWithinMaxTemplateSize(size: number): boolean {
+  return typeof size === 'number' && size > 0 && size <= MAX_TEMPLATE_FILE_SIZE_BYTES;
+}
+
+/** True if the first 4 bytes of `buffer` are the ZIP local-file-header signature. */
+export function hasZipSignature(buffer: Buffer): boolean {
+  return buffer.length >= 4 && buffer.subarray(0, 4).equals(ZIP_SIGNATURE);
+}

--- a/src/services/sharePointRetry.ts
+++ b/src/services/sharePointRetry.ts
@@ -1,0 +1,137 @@
+/**
+ * Throttle-aware retry for both SharePoint transports (on-prem NTLM and
+ * Online/Graph) — kept in one place so the two don't drift, same rationale
+ * as sharePointFileValidation.ts.
+ *
+ * Neither transport had any retry/backoff/timeout handling before this —
+ * a single 429/503 (or a hung request, with no timeout at all) used to
+ * abort the entire recursive scan. This wraps the shared request choke
+ * point (SharePointService.makeSharePointRequest / GraphSharePointService's
+ * get()) rather than every call site, so callers that deliberately expect
+ * failures (resolveSiteFromUrl's candidate-URL walk, up to 15 probes) are
+ * NOT retried here and stay fast-fail.
+ */
+import logger from '../util/logger';
+
+export const RETRYABLE_STATUSES = [429, 503];
+export const MAX_RETRY_ATTEMPTS = 2; // 2 retries = 3 total attempts
+export const BASE_BACKOFF_MS = 500; // 500ms, then 1000ms
+export const MAX_RETRY_AFTER_MS = 5000; // clamp a hostile/huge Retry-After value
+export const REQUEST_TIMEOUT_MS = 15000; // no per-request timeout existed anywhere before this
+export const DEFAULT_RETRY_BUDGET_MS = 8000;
+
+/**
+ * A scan-scoped, mutable budget shared across every retried request in one
+ * `listTemplateFiles` walk. Bounded concurrency (batches of folder fetches)
+ * means per-request retries can otherwise stack into a much longer stall
+ * than any single request's own backoff suggests — once cumulative sleep
+ * across the whole walk exceeds `limitMs`, no further request in that walk
+ * retries, it just surfaces its outcome immediately. Keeps a throttled scan
+ * from silently exceeding the frontend's 30s preview/check-conflicts
+ * timeout.
+ */
+export interface RetryBudget {
+  spentMs: number;
+  readonly limitMs: number;
+}
+
+export function createRetryBudget(limitMs: number = DEFAULT_RETRY_BUDGET_MS): RetryBudget {
+  return { spentMs: 0, limitMs };
+}
+
+/**
+ * Parses a `Retry-After` header value — either delta-seconds ("120") or an
+ * HTTP-date — into a millisecond delay, clamped to `MAX_RETRY_AFTER_MS` so
+ * a misbehaving/hostile server can't stall a request indefinitely. Returns
+ * null when the header is absent or unparseable (caller falls back to
+ * exponential backoff).
+ */
+export function parseRetryAfterMs(headerValue?: string): number | null {
+  if (!headerValue) return null;
+
+  const seconds = Number(headerValue);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS);
+  }
+
+  const dateMs = Date.parse(headerValue);
+  if (!Number.isNaN(dateMs)) {
+    const deltaMs = dateMs - Date.now();
+    return Math.min(Math.max(deltaMs, 0), MAX_RETRY_AFTER_MS);
+  }
+
+  return null;
+}
+
+/** Prefers a server-supplied `Retry-After` over exponential backoff. */
+export function backoffDelayMs(attempt: number, retryAfterHeader?: string): number {
+  const fromHeader = parseRetryAfterMs(retryAfterHeader);
+  if (fromHeader !== null) return fromHeader;
+  return BASE_BACKOFF_MS * 2 ** attempt;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface ThrottleClassification {
+  retryable: boolean;
+  retryAfter?: string;
+}
+
+export interface WithThrottleRetryOptions {
+  budget?: RetryBudget;
+  label?: string;
+}
+
+/**
+ * Runs `fn`, retrying with backoff when `classify` marks the outcome
+ * retryable — up to `MAX_RETRY_ATTEMPTS` more times, or fewer if `opts.budget`
+ * runs out first. `classify` receives the raw outcome (`value` on success,
+ * `error` on rejection) rather than a normalized shape, because the two
+ * SharePoint transports disagree on where a non-2xx status lives:
+ * on-prem's NTLM request resolves normally even on 429/503 (status lives on
+ * `outcome.value`), while Graph's OAuth request throws (status lives on
+ * `outcome.error.response`). Each call site's `classify` reads whichever
+ * side applies to it.
+ */
+export async function withThrottleRetry<T>(
+  fn: () => Promise<T>,
+  classify: (outcome: { value?: T; error?: any }) => ThrottleClassification,
+  opts: WithThrottleRetryOptions = {}
+): Promise<T> {
+  const { budget, label } = opts;
+  let attempt = 0;
+
+  for (;;) {
+    let outcome: { value?: T; error?: any };
+    let result: T | undefined;
+    let thrown: any;
+
+    try {
+      result = await fn();
+      outcome = { value: result };
+    } catch (err) {
+      thrown = err;
+      outcome = { error: err };
+    }
+
+    const { retryable, retryAfter } = classify(outcome);
+    const budgetExhausted = !!budget && budget.spentMs >= budget.limitMs;
+
+    if (!retryable || attempt >= MAX_RETRY_ATTEMPTS || budgetExhausted) {
+      if (thrown) throw thrown;
+      return result as T;
+    }
+
+    const delay = backoffDelayMs(attempt, retryAfter);
+    if (budget) budget.spentMs += delay;
+    logger.warn(
+      `SharePoint request throttled${label ? ` (${label})` : ''} — retrying in ${delay}ms (attempt ${
+        attempt + 1
+      }/${MAX_RETRY_ATTEMPTS})`
+    );
+    await sleep(delay);
+    attempt += 1;
+  }
+}

--- a/src/test/controllers/AuthController.test.ts
+++ b/src/test/controllers/AuthController.test.ts
@@ -1,0 +1,440 @@
+jest.mock('../../util/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+jest.mock('../../util/authConfig', () => ({
+  __esModule: true,
+  getAuthConfig: jest.fn(),
+  getAllowedOrigins: jest.fn(),
+}));
+jest.mock('../../services/auth/OAuthTransactionService', () => ({
+  __esModule: true,
+  createTransaction: jest.fn(),
+  consumeTransaction: jest.fn(),
+}));
+jest.mock('../../services/auth/MsalClientService', () => ({
+  __esModule: true,
+  buildAuthCodeUrl: jest.fn(),
+  redeemAuthCode: jest.fn(),
+}));
+jest.mock('../../services/auth/IdTokenValidator', () => ({
+  __esModule: true,
+  assertIdTokenClaims: jest.fn(),
+}));
+jest.mock('../../services/auth/SessionService', () => ({
+  __esModule: true,
+  createSession: jest.fn(),
+  revokeSession: jest.fn(),
+  issueHandleCode: jest.fn(),
+  consumeHandleCode: jest.fn(),
+}));
+
+import { AuthController } from '../../controllers/AuthController';
+import { getAuthConfig, getAllowedOrigins } from '../../util/authConfig';
+import { createTransaction, consumeTransaction } from '../../services/auth/OAuthTransactionService';
+import { buildAuthCodeUrl, redeemAuthCode } from '../../services/auth/MsalClientService';
+import { assertIdTokenClaims } from '../../services/auth/IdTokenValidator';
+import { createSession, revokeSession, issueHandleCode, consumeHandleCode } from '../../services/auth/SessionService';
+import { buildRes } from '../utils/testResponse';
+import { preAuthCookieName, sessionCookieName, csrfCookieName } from '../../util/cookies';
+
+const mockGetAuthConfig = getAuthConfig as jest.Mock;
+const mockGetAllowedOrigins = getAllowedOrigins as jest.Mock;
+const mockCreateTransaction = createTransaction as jest.Mock;
+const mockConsumeTransaction = consumeTransaction as jest.Mock;
+const mockBuildAuthCodeUrl = buildAuthCodeUrl as jest.Mock;
+const mockRedeemAuthCode = redeemAuthCode as jest.Mock;
+const mockAssertIdTokenClaims = assertIdTokenClaims as jest.Mock;
+const mockCreateSession = createSession as jest.Mock;
+const mockRevokeSession = revokeSession as jest.Mock;
+const mockIssueHandleCode = issueHandleCode as jest.Mock;
+const mockConsumeHandleCode = consumeHandleCode as jest.Mock;
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAllowedOrigins.mockReturnValue(['https://docgen.example.com']);
+    mockGetAuthConfig.mockReturnValue({
+      clientId: 'client-1',
+      tenantId: 'tenant-1',
+      clientSecret: 'secret-1',
+      redirectUri: 'https://docgen.example.com/auth/callback',
+      sessionSecret: 'x'.repeat(32),
+    });
+    controller = new AuthController();
+  });
+
+  describe('login', () => {
+    test('rejects a missing opener query param with 400 and creates no transaction', async () => {
+      const req: any = { query: {} };
+      const res = buildRes();
+
+      await controller.login(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ success: false, error: 'invalid_opener_origin' });
+      expect(mockCreateTransaction).not.toHaveBeenCalled();
+    });
+
+    test('rejects an opener origin not present in the allowlist', async () => {
+      const req: any = { query: { opener: 'https://attacker.example.com' } };
+      const res = buildRes();
+
+      await controller.login(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ success: false, error: 'invalid_opener_origin' });
+      expect(mockCreateTransaction).not.toHaveBeenCalled();
+    });
+
+    test('treats getAllowedOrigins() throwing as an empty allowlist (fail closed)', async () => {
+      mockGetAllowedOrigins.mockImplementationOnce(() => {
+        throw new Error('misconfigured');
+      });
+      const req: any = { query: { opener: 'https://docgen.example.com' } };
+      const res = buildRes();
+
+      await controller.login(req, res);
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    test('creates a cookie-transport transaction by default, sets the pre-auth cookie, and redirects to the auth URL', async () => {
+      mockCreateTransaction.mockResolvedValueOnce({
+        state: 'state-1',
+        codeVerifier: 'verifier-1',
+        nonce: 'nonce-1',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'cookie',
+      });
+      mockBuildAuthCodeUrl.mockResolvedValueOnce('https://login.microsoftonline.com/authorize?state=state-1');
+      const req: any = { query: { opener: 'https://docgen.example.com' } };
+      const res = buildRes();
+
+      await controller.login(req, res);
+
+      expect(mockCreateTransaction).toHaveBeenCalledWith({ openerOrigin: 'https://docgen.example.com', transport: 'cookie' });
+      expect(res.cookies[preAuthCookieName]).toBeDefined();
+      expect(res.cookies[preAuthCookieName].value).toBe('state-1');
+      expect(res.redirectedTo).toBe('https://login.microsoftonline.com/authorize?state=state-1');
+    });
+
+    test('selects the bearer transport when mode=ado', async () => {
+      mockCreateTransaction.mockResolvedValueOnce({
+        state: 's',
+        codeVerifier: 'v',
+        nonce: 'n',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'bearer',
+      });
+      mockBuildAuthCodeUrl.mockResolvedValueOnce('https://login.microsoftonline.com/authorize?...');
+      const req: any = { query: { opener: 'https://docgen.example.com', mode: 'ado' } };
+      const res = buildRes();
+
+      await controller.login(req, res);
+
+      expect(mockCreateTransaction).toHaveBeenCalledWith({ openerOrigin: 'https://docgen.example.com', transport: 'bearer' });
+    });
+  });
+
+  describe('callback', () => {
+    function baseReq(overrides: any = {}): any {
+      return {
+        query: { state: 'state-1', code: 'auth-code-1' },
+        headers: { cookie: `${preAuthCookieName}=state-1` },
+        ...overrides,
+      };
+    }
+
+    test('rejects a missing state with 400 and never consumes a transaction', async () => {
+      const req: any = { query: {}, headers: {} };
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ success: false, error: 'missing_state' });
+      expect(mockConsumeTransaction).not.toHaveBeenCalled();
+    });
+
+    test('rejects when the pre-auth cookie is missing entirely', async () => {
+      const req: any = { query: { state: 'state-1' }, headers: {} };
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ success: false, error: 'state_mismatch' });
+      expect(mockConsumeTransaction).not.toHaveBeenCalled();
+    });
+
+    test('rejects when the pre-auth cookie value does not match the state query param (login-CSRF defense)', async () => {
+      const req: any = baseReq({ query: { state: 'state-1' }, headers: { cookie: `${preAuthCookieName}=different-state` } });
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ success: false, error: 'state_mismatch' });
+      expect(mockConsumeTransaction).not.toHaveBeenCalled();
+    });
+
+    test('rejects an unknown/expired/already-consumed state with 400 (replay defense)', async () => {
+      mockConsumeTransaction.mockResolvedValueOnce(null);
+      const req: any = baseReq();
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(mockConsumeTransaction).toHaveBeenCalledWith('state-1');
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ success: false, error: 'invalid_or_expired_state' });
+      expect(mockRedeemAuthCode).not.toHaveBeenCalled();
+    });
+
+    test('clears the pre-auth cookie once the transaction is consumed', async () => {
+      mockConsumeTransaction.mockResolvedValueOnce({
+        state: 'state-1',
+        codeVerifier: 'v',
+        nonce: 'n',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'cookie',
+      });
+      mockRedeemAuthCode.mockResolvedValueOnce({
+        account: { homeAccountId: 'home-1', name: 'Eden', username: 'eden@x.com', tenantId: 'tenant-1' },
+        idTokenClaims: { nonce: 'n', tid: 'tenant-1', aud: 'client-1' },
+      });
+      mockCreateSession.mockResolvedValueOnce({ sessionToken: 'session-tok', csrfToken: 'csrf-tok' });
+      const req: any = baseReq();
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(res.clearedCookies).toContain(preAuthCookieName);
+    });
+
+    test('reports an upstream OAuth error via the postMessage callback page, not a raw JSON error', async () => {
+      mockConsumeTransaction.mockResolvedValueOnce({
+        state: 'state-1',
+        codeVerifier: 'v',
+        nonce: 'n',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'cookie',
+      });
+      const req: any = baseReq({ query: { state: 'state-1', error: 'access_denied', error_description: 'User cancelled' } });
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.text).toContain('docgen:sp-auth');
+      // The stable short code is sent separately from Entra's verbose
+      // description — the frontend maps friendly copy off the code and
+      // only falls back to the description for codes it doesn't recognize.
+      expect(res.text).toContain('access_denied');
+      expect(res.text).toContain('User cancelled');
+      expect(res.text).toContain('https://docgen.example.com');
+      expect(mockRedeemAuthCode).not.toHaveBeenCalled();
+    });
+
+    test('reports a missing code via the callback page', async () => {
+      mockConsumeTransaction.mockResolvedValueOnce({
+        state: 'state-1',
+        codeVerifier: 'v',
+        nonce: 'n',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'cookie',
+      });
+      const req: any = baseReq({ query: { state: 'state-1' } });
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(res.text).toContain('missing_code');
+      expect(mockRedeemAuthCode).not.toHaveBeenCalled();
+    });
+
+    test('validates the ID token claims against the transaction nonce and the configured tenant/client', async () => {
+      mockConsumeTransaction.mockResolvedValueOnce({
+        state: 'state-1',
+        codeVerifier: 'verifier-1',
+        nonce: 'nonce-1',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'cookie',
+      });
+      mockRedeemAuthCode.mockResolvedValueOnce({
+        account: { homeAccountId: 'home-1', name: 'Eden', username: 'eden@x.com', tenantId: 'tenant-1' },
+        idTokenClaims: { nonce: 'nonce-1', tid: 'tenant-1', aud: 'client-1' },
+      });
+      mockCreateSession.mockResolvedValueOnce({ sessionToken: 'session-tok', csrfToken: 'csrf-tok' });
+      const req: any = baseReq();
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(mockAssertIdTokenClaims).toHaveBeenCalledWith(
+        { nonce: 'nonce-1', tid: 'tenant-1', aud: 'client-1' },
+        { nonce: 'nonce-1', tenantId: 'tenant-1', clientId: 'client-1' }
+      );
+    });
+
+    test('cookie transport: sets the session and CSRF cookies and sends an ok:true callback page with no handleCode', async () => {
+      mockConsumeTransaction.mockResolvedValueOnce({
+        state: 'state-1',
+        codeVerifier: 'v',
+        nonce: 'n',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'cookie',
+      });
+      mockRedeemAuthCode.mockResolvedValueOnce({
+        account: { homeAccountId: 'home-1', name: 'Eden', username: 'eden@x.com', tenantId: 'tenant-1' },
+        idTokenClaims: { nonce: 'n', tid: 'tenant-1', aud: 'client-1' },
+      });
+      mockCreateSession.mockResolvedValueOnce({ sessionToken: 'session-tok', csrfToken: 'csrf-tok' });
+      const req: any = baseReq();
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(res.cookies[sessionCookieName].value).toBe('session-tok');
+      expect(res.cookies[csrfCookieName].value).toBe('csrf-tok');
+      expect(mockIssueHandleCode).not.toHaveBeenCalled();
+      expect(res.text).toContain('docgen:sp-auth');
+      expect(res.text).not.toContain('handleCode');
+    });
+
+    test('bearer transport: issues a handle code and sends it in the callback page, without setting cookies', async () => {
+      mockConsumeTransaction.mockResolvedValueOnce({
+        state: 'state-1',
+        codeVerifier: 'v',
+        nonce: 'n',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'bearer',
+      });
+      mockRedeemAuthCode.mockResolvedValueOnce({
+        account: { homeAccountId: 'home-1', name: 'Eden', username: 'eden@x.com', tenantId: 'tenant-1' },
+        idTokenClaims: { nonce: 'n', tid: 'tenant-1', aud: 'client-1' },
+      });
+      mockCreateSession.mockResolvedValueOnce({ sessionToken: 'session-tok', csrfToken: 'csrf-tok' });
+      mockIssueHandleCode.mockResolvedValueOnce('one-time-handle-code');
+      const req: any = baseReq();
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(mockIssueHandleCode).toHaveBeenCalledWith('session-tok');
+      expect(res.cookies[sessionCookieName]).toBeUndefined();
+      expect(res.text).toContain('one-time-handle-code');
+    });
+
+    test('a redemption failure after a valid state still reports via the callback page (trusted openerOrigin), not a raw 500', async () => {
+      mockConsumeTransaction.mockResolvedValueOnce({
+        state: 'state-1',
+        codeVerifier: 'v',
+        nonce: 'n',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'cookie',
+      });
+      mockRedeemAuthCode.mockRejectedValueOnce(new Error('invalid_grant'));
+      const req: any = baseReq();
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.text).toContain('docgen:sp-auth');
+      expect(res.text).toContain('sign_in_failed');
+    });
+
+    test('an ID-token-claims validation failure is reported the same way', async () => {
+      mockConsumeTransaction.mockResolvedValueOnce({
+        state: 'state-1',
+        codeVerifier: 'v',
+        nonce: 'n',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'cookie',
+      });
+      mockRedeemAuthCode.mockResolvedValueOnce({
+        account: { homeAccountId: 'home-1' },
+        idTokenClaims: { nonce: 'wrong', tid: 'tenant-1', aud: 'client-1' },
+      });
+      mockAssertIdTokenClaims.mockImplementationOnce(() => {
+        throw new Error('ID token nonce mismatch');
+      });
+      const req: any = baseReq();
+      const res = buildRes();
+
+      await controller.callback(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.text).toContain('sign_in_failed');
+      expect(mockCreateSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exchangeSessionHandle', () => {
+    test('rejects a missing handleCode with 400', async () => {
+      const req: any = { body: {} };
+      const res = buildRes();
+
+      await controller.exchangeSessionHandle(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ success: false, error: 'missing_handle_code' });
+      expect(mockConsumeHandleCode).not.toHaveBeenCalled();
+    });
+
+    test('rejects an unknown/expired handle code with 400', async () => {
+      mockConsumeHandleCode.mockResolvedValueOnce(null);
+      const req: any = { body: { handleCode: 'unknown-code' } };
+      const res = buildRes();
+
+      await controller.exchangeSessionHandle(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ success: false, error: 'invalid_or_expired_handle_code' });
+    });
+
+    test('returns the raw session token on success', async () => {
+      mockConsumeHandleCode.mockResolvedValueOnce({ sessionToken: 'the-session-token' });
+      const req: any = { body: { handleCode: 'valid-code' } };
+      const res = buildRes();
+
+      await controller.exchangeSessionHandle(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({ success: true, sessionToken: 'the-session-token' });
+    });
+  });
+
+  describe('getSessionInfo', () => {
+    test('returns displayName/userPrincipalName from the already-resolved session (no fresh Graph call)', async () => {
+      const req: any = { spSession: { displayName: 'Eden Zvi Schwartz', userPrincipalName: 'eden@korentec.onmicrosoft.com' } };
+      const res = buildRes();
+
+      await controller.getSessionInfo(req, res);
+
+      expect(res.body).toEqual({
+        success: true,
+        displayName: 'Eden Zvi Schwartz',
+        userPrincipalName: 'eden@korentec.onmicrosoft.com',
+      });
+    });
+  });
+
+  describe('logout', () => {
+    test('revokes the session and clears both the session and CSRF cookies', async () => {
+      const req: any = { spSessionRawToken: 'raw-session-token' };
+      const res = buildRes();
+
+      await controller.logout(req, res);
+
+      expect(mockRevokeSession).toHaveBeenCalledWith('raw-session-token');
+      expect(res.clearedCookies).toContain(sessionCookieName);
+      expect(res.clearedCookies).toContain(csrfCookieName);
+      expect(res.body).toEqual({ success: true });
+    });
+  });
+});

--- a/src/test/controllers/DataProviderController.test.ts
+++ b/src/test/controllers/DataProviderController.test.ts
@@ -137,6 +137,13 @@ describe('DataProviderController', () => {
         payload: { orgUrl: 'https://org', token: 'pat' },
       },
       {
+        name: 'getWindowsIdentity',
+        call: (c, r, s) => c.getWindowsIdentity(r, s),
+        req: { headers, query: { identityId: 'vsid-1' } },
+        path: '/azure/user/windows-identity',
+        payload: { orgUrl: 'https://org', token: 'pat', identityId: 'vsid-1' },
+      },
+      {
         name: 'getCollectionLinkTypes',
         call: (c, r, s) => c.getCollectionLinkTypes(r, s),
         req: { headers },
@@ -492,6 +499,7 @@ describe('DataProviderController', () => {
     const methods = [
       'getTeamProjects',
       'getUserProfile',
+      'getWindowsIdentity',
       'getCollectionLinkTypes',
       'getSharedQueries',
       'getFieldsByType',

--- a/src/test/controllers/MinioController.test.ts
+++ b/src/test/controllers/MinioController.test.ts
@@ -97,6 +97,24 @@ describe('MinioController', () => {
     expect(result[0].inputDetailsKey).toBe('p/STD/__input__/file1.input.json');
   });
 
+  test('getBucketFileList: decodes sourceLastModified metadata', async () => {
+    const req: any = { params: { bucketName: 'templates' }, query: { projectName: 'p', docType: 'STD' } };
+    const res = buildRes();
+
+    const stream = makeStream([{ name: 'p/STD/file1.dotx', etag: '123' }]);
+    mockS3.listObjectsV2.mockReturnValueOnce(stream);
+    mockS3.statObject.mockResolvedValueOnce({
+      metaData: { sourcelastmodified: '2024-05-01T10:00:00Z' },
+    });
+
+    const p = controller.getBucketFileList(req, res);
+    stream.emitAll();
+    const result: any = await p;
+
+    expect(result.length).toBe(1);
+    expect(result[0].sourceLastModified).toBe('2024-05-01T10:00:00Z');
+  });
+
   test('getBucketFileList: decodes encoded metadata values to original unicode content', async () => {
     const req: any = { params: { bucketName: 'templates' }, query: { projectName: 'p', docType: 'STD' } };
     const res = buildRes();
@@ -231,6 +249,7 @@ describe('MinioController', () => {
     expect(result.length).toBe(1);
     expect(result[0].createdBy).toBe('');
     expect(result[0].inputSummary).toBe('');
+    expect(result[0].sourceLastModified).toBe('');
   });
 
   /**
@@ -316,6 +335,58 @@ describe('MinioController', () => {
     expect(receivedMetadata.createdById.startsWith("utf8''")).toBe(true);
     expect(receivedMetadata.createdBy).not.toContain('\n');
     expect(receivedMetadata.createdBy).not.toContain('\r');
+  });
+
+  test('uploadFile: attaches sourceLastModified metadata when provided', async () => {
+    mockS3.bucketExists.mockResolvedValueOnce(true);
+    let receivedMetadata: Record<string, string> = {};
+    mockS3.putObject.mockImplementation(
+      (_b: string, _o: string, _s: any, _len: number, meta: Record<string, string>, cb: Function) => {
+        receivedMetadata = meta;
+        cb(null, { etag: 'etag-source-last-modified' });
+      },
+    );
+
+    const req: any = {
+      body: {
+        bucketName: 'attachments',
+        teamProjectName: 'p',
+        docType: 'STD',
+        isExternalUrl: false,
+        sourceLastModified: '2024-05-01T10:00:00Z',
+      },
+      file: {
+        mimetype: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        originalname: 'f.docx',
+        path: '/tmp/f.docx',
+      },
+    };
+
+    await expect(controller.uploadFile(req, {} as any)).resolves.toEqual({ fileItem: expect.any(Object) });
+    expect(receivedMetadata.sourceLastModified).toBe('2024-05-01T10:00:00Z');
+  });
+
+  test('uploadFile: omits sourceLastModified metadata when absent', async () => {
+    mockS3.bucketExists.mockResolvedValueOnce(true);
+    let receivedMetadata: Record<string, string> = {};
+    mockS3.putObject.mockImplementation(
+      (_b: string, _o: string, _s: any, _len: number, meta: Record<string, string>, cb: Function) => {
+        receivedMetadata = meta;
+        cb(null, { etag: 'etag-no-source-last-modified' });
+      },
+    );
+
+    const req: any = {
+      body: { bucketName: 'attachments', teamProjectName: 'p', docType: 'STD', isExternalUrl: false },
+      file: {
+        mimetype: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        originalname: 'f.docx',
+        path: '/tmp/f.docx',
+      },
+    };
+
+    await expect(controller.uploadFile(req, {} as any)).resolves.toEqual({ fileItem: expect.any(Object) });
+    expect(receivedMetadata.sourceLastModified).toBeUndefined();
   });
 
   test('downloadFile: sets RFC 6266 content-disposition for non-ASCII filename', async () => {

--- a/src/test/controllers/SharePointController.test.ts
+++ b/src/test/controllers/SharePointController.test.ts
@@ -10,6 +10,7 @@ const mockSvc = {
   testConnection: jest.fn(),
   listTemplateFiles: jest.fn(),
   downloadFile: jest.fn(),
+  resolveSiteFromUrl: jest.fn(),
 };
 
 jest.mock('../../services/SharePointService', () => ({
@@ -94,6 +95,98 @@ describe('SharePointController', () => {
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.body).toEqual({ success: false, message: 'tc-fail' });
     });
+
+    // Regression: an Online config's whole location lives in siteUrl (the
+    // pasted sharing/folder link) — library/folder are legitimately blank,
+    // and the request must not be rejected for that reason when oauthToken
+    // is present. This was a real bug: the blanket `!library || !folder`
+    // check 400'd every Online request silently (no log line at all,
+    // before the handler's own logging ever ran), so Online sync appeared
+    // to just not connect.
+    test('200 with oauthToken even when library/folder are empty (Online config)', async () => {
+      const req: any = {
+        body: { siteUrl: 'https://tenant.sharepoint.com/:f:/r/x', library: '', folder: '', oauthToken: { accessToken: 't' } },
+      };
+      const res = buildRes();
+      mockSvc.testConnection.mockResolvedValueOnce({ success: true });
+
+      await controller.testConnection(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test('400 with NTLM credentials when folder is empty (on-prem still needs a folder)', async () => {
+      const req: any = {
+        body: { siteUrl: 'http://sp-server/sites/project', library: '', folder: '', credentials: { username: 'u', password: 'p' } },
+      };
+      const res = buildRes();
+
+      await controller.testConnection(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockSvc.testConnection).not.toHaveBeenCalled();
+    });
+
+    test('200 with NTLM credentials when library is empty but folder is set (paste-a-URL on-prem config)', async () => {
+      const req: any = {
+        body: {
+          siteUrl: 'http://sp-server/sites/project',
+          library: '',
+          folder: 'Shared Documents/Templates',
+          credentials: { username: 'u', password: 'p' },
+        },
+      };
+      const res = buildRes();
+      mockSvc.testConnection.mockResolvedValueOnce({ success: true });
+
+      await controller.testConnection(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('resolveUrl', () => {
+    test('400 on missing fields', async () => {
+      const req: any = { body: {} };
+      const res = buildRes();
+      await controller.resolveUrl(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    test('200 on success', async () => {
+      const req: any = {
+        body: { url: 'http://sp-server/sites/project/Templates', credentials: { username: 'u', password: 'p' } },
+      };
+      const res = buildRes();
+      mockSvc.resolveSiteFromUrl.mockResolvedValueOnce({
+        siteUrl: 'http://sp-server/sites/project',
+        library: '',
+        folder: 'Templates',
+      });
+
+      await controller.resolveUrl(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.body).toEqual({
+        success: true,
+        siteUrl: 'http://sp-server/sites/project',
+        library: '',
+        folder: 'Templates',
+      });
+    });
+
+    test('500 on service error', async () => {
+      const req: any = {
+        body: { url: 'http://sp-server/sites/project/Templates', credentials: { username: 'u', password: 'p' } },
+      };
+      const res = buildRes();
+      mockSvc.resolveSiteFromUrl.mockRejectedValueOnce(new Error('resolve-fail'));
+
+      await controller.resolveUrl(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.body).toEqual({ success: false, message: 'resolve-fail' });
+    });
   });
 
   describe('listFiles', () => {
@@ -131,6 +224,55 @@ describe('SharePointController', () => {
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.body).toEqual({ success: false, message: 'list-fail' });
     });
+
+    // Regression: an expired/invalid Graph token is an expected client-side
+    // condition, not a server error — it must not read as a 500.
+    test('401 when the underlying error carries a status (expired token)', async () => {
+      const res = buildRes();
+      const expiredTokenError: any = new Error('Graph access token expired or invalid — paste a fresh one');
+      expiredTokenError.status = 401;
+      mockSvc.listTemplateFiles.mockRejectedValueOnce(expiredTokenError);
+      await controller.listFiles(
+        { body: { siteUrl: 'u', library: 'l', folder: 'f', oauthToken: { accessToken: 't' } } } as any,
+        res
+      );
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.body).toEqual({
+        success: false,
+        message: 'Graph access token expired or invalid — paste a fresh one',
+      });
+    });
+
+    // Regression: this exact request shape (Online, no library/folder) was
+    // silently rejected with 400 before the fix — the actual bug found when
+    // testing the real "Sync from SharePoint" flow end to end.
+    test('200 with oauthToken even when library/folder are empty (Online config)', async () => {
+      const res = buildRes();
+      mockSvc.listTemplateFiles.mockResolvedValueOnce([{ name: 'SVD-template.docx' }]);
+      await controller.listFiles(
+        {
+          body: {
+            siteUrl: 'https://tenant.sharepoint.com/:f:/r/teams/x/Shared Documents/DocGen Templates',
+            library: '',
+            folder: '',
+            oauthToken: { accessToken: 't' },
+          },
+        } as any,
+        res
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.body).toEqual({ success: true, files: [{ name: 'SVD-template.docx' }] });
+    });
+
+    test('400 with NTLM credentials when folder is empty', async () => {
+      const res = buildRes();
+      await controller.listFiles(
+        { body: { siteUrl: 'http://sp-server/sites/project', library: '', folder: '', credentials: { username: 'u', password: 'p' } } } as any,
+        res
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockSvc.listTemplateFiles).not.toHaveBeenCalled();
+    });
   });
 
   describe('checkConflicts', () => {
@@ -142,6 +284,31 @@ describe('SharePointController', () => {
       const res = buildRes();
       await controller.checkConflicts({ body: {} } as any, res);
       expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    // Regression: 'shared' (standard templates library) is not a valid sync
+    // target — must be rejected server-side, not just hidden in the UI.
+    test('400 when projectName is "shared"', async () => {
+      const res = buildRes();
+      await controller.checkConflicts(
+        {
+          body: {
+            siteUrl: 'u',
+            library: 'l',
+            folder: 'f',
+            oauthToken: { accessToken: 't' },
+            bucketName: 'templates',
+            projectName: 'shared',
+          },
+        } as any,
+        res
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.body).toEqual({
+        success: false,
+        message: 'A team project must be selected to sync templates',
+      });
+      expect(mockSvc.listTemplateFiles).not.toHaveBeenCalled();
     });
     /**
      * checkConflicts (computes conflict/new/invalid)
@@ -176,6 +343,58 @@ describe('SharePointController', () => {
       expect(res.body.conflicts.length).toBe(1);
       expect(res.body.newFiles.length).toBe(1);
       expect(res.body.invalidFiles.length).toBe(1);
+    });
+
+    test('forwards timeCreated/timeLastModified onto both conflicts and newFiles entries', async () => {
+      const files = [
+        {
+          name: 'STD/file1.dotx',
+          length: 10,
+          docType: 'STD',
+          timeCreated: '2023-12-01T00:00:00Z',
+          timeLastModified: '2024-01-01T00:00:00Z',
+        },
+        {
+          name: 'STR/file2.dotx',
+          length: 30,
+          docType: 'STR',
+          timeCreated: '2023-11-01T00:00:00Z',
+          timeLastModified: '2023-12-15T00:00:00Z',
+        },
+      ];
+      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockGetMinioFiles.mockResolvedValueOnce([{ name: 'project/STD/file1.dotx', size: 99 }]); // conflict (size changed)
+      mockGetMinioFiles.mockResolvedValueOnce([]); // STR — new
+
+      const res = buildRes();
+      await controller.checkConflicts(
+        {
+          body: {
+            siteUrl: 'u',
+            library: 'l',
+            folder: 'f',
+            oauthToken: { accessToken: 't' },
+            bucketName: 'templates',
+            projectName: 'project',
+          },
+        } as any,
+        res
+      );
+
+      expect(res.body.conflicts).toEqual([
+        expect.objectContaining({
+          name: 'STD/file1.dotx',
+          timeCreated: '2023-12-01T00:00:00Z',
+          timeLastModified: '2024-01-01T00:00:00Z',
+        }),
+      ]);
+      expect(res.body.newFiles).toEqual([
+        expect.objectContaining({
+          name: 'STR/file2.dotx',
+          timeCreated: '2023-11-01T00:00:00Z',
+          timeLastModified: '2023-12-15T00:00:00Z',
+        }),
+      ]);
     });
 
     test('accepts STP as a valid docType (not invalid)', async () => {
@@ -289,6 +508,31 @@ describe('SharePointController', () => {
       await controller.syncTemplates({ body: {} } as any, res);
       expect(res.status).toHaveBeenCalledWith(400);
     });
+
+    // Regression: 'shared' (standard templates library) is not a valid sync
+    // target — must be rejected server-side, not just hidden in the UI.
+    test('400 when projectName is "shared"', async () => {
+      const res = buildRes();
+      await controller.syncTemplates(
+        {
+          body: {
+            siteUrl: 'u',
+            library: 'l',
+            folder: 'f',
+            oauthToken: { accessToken: 't' },
+            bucketName: 'templates',
+            projectName: 'shared',
+          },
+        } as any,
+        res
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.body).toEqual({
+        success: false,
+        message: 'A team project must be selected to sync templates',
+      });
+      expect(mockSvc.listTemplateFiles).not.toHaveBeenCalled();
+    });
     /**
      * syncTemplates (skip identical, upload changed)
      * Skips identical templates and uploads only changed ones; responds with synced and skipped lists.
@@ -327,6 +571,43 @@ describe('SharePointController', () => {
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.body.syncedFiles).toEqual(['STR/file2.dotx']);
       expect(res.body.skippedFiles).toContain('STD/file1.dotx');
+    });
+
+    test('forwards SharePoint timeLastModified into the MinIO upload body', async () => {
+      const files = [
+        {
+          name: 'STD/file1.dotx',
+          length: 10,
+          docType: 'STD',
+          serverRelativeUrl: '/x',
+          timeLastModified: '2024-05-01T10:00:00Z',
+        },
+      ];
+      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockGetMinioFiles.mockResolvedValueOnce([]);
+      mockSvc.downloadFile.mockResolvedValueOnce(Buffer.from('abcd'));
+
+      const res = buildRes();
+      await controller.syncTemplates(
+        {
+          body: {
+            siteUrl: 'u',
+            library: 'l',
+            folder: 'f',
+            oauthToken: { accessToken: 't' },
+            bucketName: 'templates',
+            projectName: 'project',
+          },
+        } as any,
+        res
+      );
+
+      expect((MinioController.prototype as any).uploadFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ sourceLastModified: '2024-05-01T10:00:00Z' }),
+        }),
+        expect.anything()
+      );
     });
 
     test('uploads STP files without docType validation failure', async () => {
@@ -546,10 +827,72 @@ describe('SharePointController', () => {
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
+    test('saveConfig: is scoped by userId only, ignoring any projectName in the body', async () => {
+      const res = buildRes();
+      const { __mockConfigModel } = require('../../models/SharePointConfig');
+      __mockConfigModel.findOne.mockResolvedValueOnce(null);
+      await controller.saveConfig(
+        {
+          body: {
+            userId: 'u1',
+            projectName: 'some-project',
+            siteUrl: 's',
+            library: 'l',
+            folder: 'f',
+            displayName: 'd',
+          },
+        } as any,
+        res
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(__mockConfigModel.findOne).toHaveBeenCalledWith({ userId: 'u1' });
+    });
+
     test('saveConfig: missing fields', async () => {
       const res = buildRes();
       await controller.saveConfig({ body: {} } as any, res);
       expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    // Regression: a missing/non-string userId must 400, not silently become
+    // findOne({}) — which would match and overwrite an arbitrary other
+    // user's saved config.
+    test('saveConfig: 400 when userId is missing, without querying the model', async () => {
+      const res = buildRes();
+      const { __mockConfigModel } = require('../../models/SharePointConfig');
+      await controller.saveConfig({ body: { siteUrl: 's' } } as any, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(__mockConfigModel.findOne).not.toHaveBeenCalled();
+    });
+
+    test('saveConfig: 400 when userId is not a string (NoSQL-injection-shaped body)', async () => {
+      const res = buildRes();
+      const { __mockConfigModel } = require('../../models/SharePointConfig');
+      await controller.saveConfig({ body: { siteUrl: 's', userId: { $ne: null } } } as any, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(__mockConfigModel.findOne).not.toHaveBeenCalled();
+    });
+
+    // Regression: an Online config saves with library/folder both blank —
+    // the whole location lives in siteUrl. Only siteUrl is required now.
+    test('saveConfig: 200 with library/folder both empty (Online config)', async () => {
+      const res = buildRes();
+      const { __mockConfigModel } = require('../../models/SharePointConfig');
+      __mockConfigModel.findOne.mockResolvedValueOnce(null);
+      await controller.saveConfig(
+        {
+          body: {
+            userId: 'u1',
+            projectName: 'p1',
+            siteUrl: 'https://tenant.sharepoint.com/:f:/r/teams/x/Shared Documents/DocGen Templates',
+            library: '',
+            folder: '',
+            displayName: 'Prod SharePoint',
+          },
+        } as any,
+        res
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
     });
 
     test('saveConfig: create new config', async () => {
@@ -640,6 +983,26 @@ describe('SharePointController', () => {
       expect(res2.body.success).toBe(true);
     });
 
+    test('getConfig: returns the app-level config with no projectName in the query at all', async () => {
+      const { __mockConfigModel } = require('../../models/SharePointConfig');
+      __mockConfigModel.findOne.mockImplementationOnce(() => ({
+        sort: jest.fn().mockResolvedValue({
+          userId: 'u1',
+          siteUrl: 's',
+          library: 'l',
+          folder: 'f',
+          displayName: 'd',
+          lastUsed: new Date(0),
+          save: jest.fn().mockResolvedValue(null),
+        }),
+      }));
+      const res = buildRes();
+      await controller.getConfig({ headers: { 'x-user-id': 'u1' }, query: {} } as any, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.body.success).toBe(true);
+      expect(__mockConfigModel.findOne).toHaveBeenCalledWith({ userId: 'u1' });
+    });
+
     /**
      * getConfigs (requires userId)
      * Returns 400 if the x-user-id header is missing.
@@ -699,7 +1062,7 @@ describe('SharePointController', () => {
       expect(res.body).toEqual({ success: false, message: 'all-configs-fail' });
     });
 
-    test('deleteConfig: missing fields and success', async () => {
+    test('deleteConfig: missing userId and success (no projectName required)', async () => {
       const res1 = buildRes();
       await controller.deleteConfig({ headers: {}, query: {} } as any, res1);
       expect(res1.status).toHaveBeenCalledWith(400);
@@ -707,11 +1070,9 @@ describe('SharePointController', () => {
       const { __mockConfigModel } = require('../../models/SharePointConfig');
       __mockConfigModel.deleteOne.mockResolvedValueOnce({ deletedCount: 1 });
       const res2 = buildRes();
-      await controller.deleteConfig(
-        { headers: { 'x-user-id': 'u1' }, query: { projectName: 'p1' } } as any,
-        res2
-      );
+      await controller.deleteConfig({ headers: { 'x-user-id': 'u1' }, query: {} } as any, res2);
       expect(res2.status).toHaveBeenCalledWith(200);
+      expect(__mockConfigModel.deleteOne).toHaveBeenCalledWith({ userId: 'u1' });
     });
 
     test('deleteConfig: returns 404 when configuration not found', async () => {

--- a/src/test/controllers/SharePointController.test.ts
+++ b/src/test/controllers/SharePointController.test.ts
@@ -205,13 +205,13 @@ describe('SharePointController', () => {
      */
     test('200 on success', async () => {
       const res = buildRes();
-      mockSvc.listTemplateFiles.mockResolvedValueOnce([{ name: 'a' }]);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files: [{ name: 'a' }], truncated: false });
       await controller.listFiles(
         { body: { siteUrl: 'u', library: 'l', folder: 'f', oauthToken: { accessToken: 't' } } } as any,
         res
       );
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.body).toEqual({ success: true, files: [{ name: 'a' }] });
+      expect(res.body).toEqual({ success: true, files: [{ name: 'a' }], truncated: false, skippedFolders: [] });
     });
 
     test('500 on service error', async () => {
@@ -248,7 +248,7 @@ describe('SharePointController', () => {
     // testing the real "Sync from SharePoint" flow end to end.
     test('200 with oauthToken even when library/folder are empty (Online config)', async () => {
       const res = buildRes();
-      mockSvc.listTemplateFiles.mockResolvedValueOnce([{ name: 'SVD-template.docx' }]);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files: [{ name: 'SVD-template.docx' }], truncated: false });
       await controller.listFiles(
         {
           body: {
@@ -261,7 +261,12 @@ describe('SharePointController', () => {
         res
       );
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.body).toEqual({ success: true, files: [{ name: 'SVD-template.docx' }] });
+      expect(res.body).toEqual({
+        success: true,
+        files: [{ name: 'SVD-template.docx' }],
+        truncated: false,
+        skippedFolders: [],
+      });
     });
 
     test('400 with NTLM credentials when folder is empty', async () => {
@@ -314,13 +319,13 @@ describe('SharePointController', () => {
      * checkConflicts (computes conflict/new/invalid)
      * Aggregates SharePoint and MinIO results to identify conflicts, new files, and invalid files by docType.
      */
-    test('returns conflicts, newFiles, invalidFiles', async () => {
+    test('returns conflicts, newFiles (including a needs-mapping row for an unrecognized docType)', async () => {
       const files = [
-        { name: 'STD/file1.dotx', length: 10, docType: 'STD' },
-        { name: 'BAD/file2.dotx', length: 20, docType: 'BAD' },
-        { name: 'STR/file3.dotx', length: 30, docType: 'STR' },
+        { name: 'STD/file1.dotx', length: 10, docType: 'STD', relativePath: 'STD/file1.dotx' },
+        { name: 'BAD/file2.dotx', length: 20, docType: 'BAD', relativePath: 'BAD/file2.dotx' },
+        { name: 'STR/file3.dotx', length: 30, docType: 'STR', relativePath: 'STR/file3.dotx' },
       ];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockResolvedValueOnce([{ name: 'project/STD/file1.dotx', size: 99 }]); // cause conflict by size change
       mockGetMinioFiles.mockResolvedValueOnce([]); // for STR
 
@@ -341,8 +346,60 @@ describe('SharePointController', () => {
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.body.conflicts.length).toBe(1);
-      expect(res.body.newFiles.length).toBe(1);
-      expect(res.body.invalidFiles.length).toBe(1);
+      // BAD/file2.dotx has an unrecognized docType — it's no longer
+      // hard-rejected into invalidFiles, it's surfaced as a reviewable row
+      // (needsDocType: true) so the dialog can let the user map it.
+      expect(res.body.newFiles.length).toBe(2);
+      expect(res.body.newFiles).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'BAD/file2.dotx', docType: '', needsDocType: true })])
+      );
+      expect(res.body.invalidFiles.length).toBe(0);
+    });
+
+    test('defaults skippedFolders to [] when the service returns none', async () => {
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files: [], truncated: false });
+
+      const res = buildRes();
+      await controller.checkConflicts(
+        {
+          body: {
+            siteUrl: 'u',
+            library: 'l',
+            folder: 'f',
+            oauthToken: { accessToken: 't' },
+            bucketName: 'templates',
+            projectName: 'project',
+          },
+        } as any,
+        res
+      );
+
+      expect(res.body.skippedFolders).toEqual([]);
+    });
+
+    test('echoes skippedFolders from the service in the response', async () => {
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({
+        files: [],
+        truncated: false,
+        skippedFolders: [{ relativePath: 'Denied', reason: 'Access is denied.' }],
+      });
+
+      const res = buildRes();
+      await controller.checkConflicts(
+        {
+          body: {
+            siteUrl: 'u',
+            library: 'l',
+            folder: 'f',
+            oauthToken: { accessToken: 't' },
+            bucketName: 'templates',
+            projectName: 'project',
+          },
+        } as any,
+        res
+      );
+
+      expect(res.body.skippedFolders).toEqual([{ relativePath: 'Denied', reason: 'Access is denied.' }]);
     });
 
     test('forwards timeCreated/timeLastModified onto both conflicts and newFiles entries', async () => {
@@ -362,7 +419,7 @@ describe('SharePointController', () => {
           timeLastModified: '2023-12-15T00:00:00Z',
         },
       ];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockResolvedValueOnce([{ name: 'project/STD/file1.dotx', size: 99 }]); // conflict (size changed)
       mockGetMinioFiles.mockResolvedValueOnce([]); // STR — new
 
@@ -399,7 +456,7 @@ describe('SharePointController', () => {
 
     test('accepts STP as a valid docType (not invalid)', async () => {
       const files = [{ name: 'STP/stp-template.dotx', length: 12, docType: 'STP' }];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockResolvedValueOnce([]);
 
       const res = buildRes();
@@ -426,7 +483,7 @@ describe('SharePointController', () => {
 
     test('accepts SYSRS as a valid docType (not invalid)', async () => {
       const files = [{ name: 'SYSRS/sysrs-template.dotx', length: 14, docType: 'SYSRS' }];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockResolvedValueOnce([]);
 
       const res = buildRes();
@@ -453,7 +510,7 @@ describe('SharePointController', () => {
 
     test('skips identical files without conflicts or new files', async () => {
       const files = [{ name: 'STD/file1.dotx', length: 10, docType: 'STD' }];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockResolvedValueOnce([{ name: 'project/STD/file1.dotx', size: 10 }]);
 
       const res = buildRes();
@@ -539,14 +596,14 @@ describe('SharePointController', () => {
      */
     test('skips identical and uploads others', async () => {
       const files = [
-        { name: 'STD/file1.dotx', length: 10, docType: 'STD', serverRelativeUrl: '/x' },
-        { name: 'STR/file2.dotx', length: 20, docType: 'STR', serverRelativeUrl: '/y' },
+        { name: 'STD/file1.dotx', length: 10, docType: 'STD', serverRelativeUrl: '/x', relativePath: 'STD/file1.dotx' },
+        { name: 'STR/file2.dotx', length: 20, docType: 'STR', serverRelativeUrl: '/y', relativePath: 'STR/file2.dotx' },
       ];
       mockSvc.listTemplateFiles.mockReset();
       mockGetMinioFiles.mockReset();
       mockSvc.downloadFile.mockReset();
       // First get list
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       // Identical check calls per file
       mockGetMinioFiles.mockResolvedValueOnce([{ name: 'project/STD/file1.dotx', size: 10 }]); // identical -> skip
       mockGetMinioFiles.mockResolvedValueOnce([]); // STR -> not identical
@@ -571,6 +628,77 @@ describe('SharePointController', () => {
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.body.syncedFiles).toEqual(['STR/file2.dotx']);
       expect(res.body.skippedFiles).toContain('STD/file1.dotx');
+      expect(res.body.skippedFolders).toEqual([]);
+    });
+
+    test('fails the second of two files that would collide at the same MinIO destination (duplicate basename, same docType, different source folders)', async () => {
+      // Recursion permits the same basename under two different SharePoint
+      // folders — if both map to the same docType, they'd both write to
+      // bucket/project/STD/template.dotx. Only the first should sync; the
+      // second must be reported in failedFiles, not silently overwrite it.
+      const files = [
+        { name: 'template.dotx', length: 10, docType: 'STD', serverRelativeUrl: '/a', relativePath: 'FolderA/template.dotx' },
+        { name: 'template.dotx', length: 20, docType: 'STD', serverRelativeUrl: '/b', relativePath: 'FolderB/template.dotx' },
+      ];
+      mockSvc.listTemplateFiles.mockReset();
+      mockGetMinioFiles.mockReset();
+      mockSvc.downloadFile.mockReset();
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
+      // Identical-file check runs over both files before duplicate-destination detection.
+      mockGetMinioFiles.mockResolvedValueOnce([]); // FolderA/template.dotx
+      mockGetMinioFiles.mockResolvedValueOnce([]); // FolderB/template.dotx
+      mockSvc.downloadFile.mockResolvedValueOnce(Buffer.from('abcd')); // only the kept (first) file downloads
+
+      const res = buildRes();
+      await controller.syncTemplates(
+        {
+          body: {
+            siteUrl: 'u',
+            library: 'l',
+            folder: 'f',
+            oauthToken: { accessToken: 't' },
+            bucketName: 'templates',
+            projectName: 'project',
+          },
+        } as any,
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.body.syncedFiles).toEqual(['template.dotx']);
+      expect(mockSvc.downloadFile).toHaveBeenCalledTimes(1);
+      expect(res.body.failedFiles).toHaveLength(1);
+      expect(res.body.failedFiles[0].name).toBe('template.dotx');
+      expect(res.body.failedFiles[0].error).toContain('same destination');
+      expect(res.body.failedFiles[0].error).toContain('FolderA/template.dotx');
+    });
+
+    test('echoes skippedFolders from the service in the sync response', async () => {
+      mockSvc.listTemplateFiles.mockReset();
+      mockGetMinioFiles.mockReset();
+      mockSvc.downloadFile.mockReset();
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({
+        files: [],
+        truncated: false,
+        skippedFolders: [{ relativePath: 'Denied', reason: 'Access is denied.' }],
+      });
+
+      const res = buildRes();
+      await controller.syncTemplates(
+        {
+          body: {
+            siteUrl: 'u',
+            library: 'l',
+            folder: 'f',
+            oauthToken: { accessToken: 't' },
+            bucketName: 'templates',
+            projectName: 'project',
+          },
+        } as any,
+        res
+      );
+
+      expect(res.body.skippedFolders).toEqual([{ relativePath: 'Denied', reason: 'Access is denied.' }]);
     });
 
     test('forwards SharePoint timeLastModified into the MinIO upload body', async () => {
@@ -583,7 +711,7 @@ describe('SharePointController', () => {
           timeLastModified: '2024-05-01T10:00:00Z',
         },
       ];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockResolvedValueOnce([]);
       mockSvc.downloadFile.mockResolvedValueOnce(Buffer.from('abcd'));
 
@@ -612,7 +740,7 @@ describe('SharePointController', () => {
 
     test('uploads STP files without docType validation failure', async () => {
       const files = [{ name: 'STP/stp-template.dotx', length: 20, docType: 'STP', serverRelativeUrl: '/z' }];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockResolvedValueOnce([]);
       mockSvc.downloadFile.mockResolvedValueOnce(Buffer.from('stp'));
 
@@ -645,7 +773,7 @@ describe('SharePointController', () => {
           serverRelativeUrl: '/sysrs',
         },
       ];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockResolvedValueOnce([]);
       mockSvc.downloadFile.mockResolvedValueOnce(Buffer.from('sysrs'));
 
@@ -671,7 +799,7 @@ describe('SharePointController', () => {
 
     test('handles getMinioFiles error when checking identical', async () => {
       const files = [{ name: 'STD/file1.dotx', length: 10, docType: 'STD', serverRelativeUrl: '/x' }];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockRejectedValueOnce(new Error('minio-check-fail'));
       mockSvc.downloadFile.mockResolvedValueOnce(Buffer.from('abcd'));
 
@@ -696,7 +824,7 @@ describe('SharePointController', () => {
 
     test('marks file as failed when no docType available', async () => {
       const files = [{ name: 'noDoc/file1.dotx', length: 10, docType: undefined, serverRelativeUrl: '/x' }];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockResolvedValueOnce([]);
       mockSvc.downloadFile.mockResolvedValueOnce(Buffer.from('abcd'));
 
@@ -721,7 +849,7 @@ describe('SharePointController', () => {
 
     test('marks file as failed when docType is invalid', async () => {
       const files = [{ name: 'BAD/file1.dotx', length: 10, docType: 'BAD', serverRelativeUrl: '/x' }];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockResolvedValueOnce([]);
       mockSvc.downloadFile.mockResolvedValueOnce(Buffer.from('abcd'));
 
@@ -746,7 +874,7 @@ describe('SharePointController', () => {
 
     test('records failedFiles entry when upload fails', async () => {
       const files = [{ name: 'STD/file1.dotx', length: 10, docType: 'STD', serverRelativeUrl: '/x' }];
-      mockSvc.listTemplateFiles.mockResolvedValueOnce(files);
+      mockSvc.listTemplateFiles.mockResolvedValueOnce({ files, truncated: false });
       mockGetMinioFiles.mockResolvedValueOnce([]);
       mockSvc.downloadFile.mockResolvedValueOnce(Buffer.from('abcd'));
 

--- a/src/test/controllers/SharePointController.test.ts
+++ b/src/test/controllers/SharePointController.test.ts
@@ -15,6 +15,15 @@ const mockSvc = {
 
 jest.mock('../../services/SharePointService', () => ({
   SharePointService: jest.fn().mockImplementation(() => mockSvc),
+  isSharePointOnlineUrl: (siteUrl: string) => siteUrl.toLowerCase().includes('.sharepoint.com'),
+}));
+
+// Keeps this file from pulling in the real @azure/msal-node -> mongoose
+// chain (via MsalClientService -> MongoTokenCachePlugin -> the MsalTokenCache
+// model) — these tests exercise SharePointController's own routing logic,
+// not token acquisition, which is covered by MsalClientService's own tests.
+jest.mock('../../services/auth/MsalClientService', () => ({
+  createTokenProvider: jest.fn(() => jest.fn().mockResolvedValue('mock-graph-token')),
 }));
 
 const mockGetMinioFiles = jest.fn();
@@ -76,7 +85,7 @@ describe('SharePointController', () => {
      */
     test('200 on success', async () => {
       const req: any = {
-        body: { siteUrl: 'u', library: 'l', folder: 'f', oauthToken: { accessToken: 't' } },
+        body: { siteUrl: 'u', library: 'l', folder: 'f', credentials: { username: 'u', password: 'p' } },
       };
       const res = buildRes();
       mockSvc.testConnection.mockResolvedValueOnce({ success: true });
@@ -87,7 +96,7 @@ describe('SharePointController', () => {
 
     test('500 on service error', async () => {
       const req: any = {
-        body: { siteUrl: 'u', library: 'l', folder: 'f', oauthToken: { accessToken: 't' } },
+        body: { siteUrl: 'u', library: 'l', folder: 'f', credentials: { username: 'u', password: 'p' } },
       };
       const res = buildRes();
       mockSvc.testConnection.mockRejectedValueOnce(new Error('tc-fail'));
@@ -98,14 +107,15 @@ describe('SharePointController', () => {
 
     // Regression: an Online config's whole location lives in siteUrl (the
     // pasted sharing/folder link) — library/folder are legitimately blank,
-    // and the request must not be rejected for that reason when oauthToken
+    // and the request must not be rejected for that reason when a session
     // is present. This was a real bug: the blanket `!library || !folder`
     // check 400'd every Online request silently (no log line at all,
     // before the handler's own logging ever ran), so Online sync appeared
     // to just not connect.
-    test('200 with oauthToken even when library/folder are empty (Online config)', async () => {
+    test('200 with a session even when library/folder are empty (Online config)', async () => {
       const req: any = {
-        body: { siteUrl: 'https://tenant.sharepoint.com/:f:/r/x', library: '', folder: '', oauthToken: { accessToken: 't' } },
+        body: { siteUrl: 'https://tenant.sharepoint.com/:f:/r/x', library: '', folder: '' },
+        spSession: { homeAccountId: 'home-1' },
       };
       const res = buildRes();
       mockSvc.testConnection.mockResolvedValueOnce({ success: true });
@@ -142,6 +152,92 @@ describe('SharePointController', () => {
       await controller.testConnection(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('resolveAuth (hard cutover — Online authenticates via session only)', () => {
+    test('explicitly rejects a client-supplied oauthToken with 400 oauth_token_not_accepted, never silently ignoring it', async () => {
+      const req: any = {
+        body: { siteUrl: 'https://tenant.sharepoint.com/:f:/r/x', library: '', folder: '', oauthToken: { accessToken: 't' } },
+        spSession: { homeAccountId: 'home-1' },
+      };
+      const res = buildRes();
+
+      await controller.testConnection(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.body).toEqual({ success: false, message: 'oauth_token_not_accepted' });
+      expect(mockSvc.testConnection).not.toHaveBeenCalled();
+    });
+
+    test('rejects oauthToken even for an on-prem siteUrl (not just Online)', async () => {
+      const req: any = {
+        body: { siteUrl: 'http://sp-server/sites/project', library: 'l', folder: 'f', oauthToken: { accessToken: 't' } },
+      };
+      const res = buildRes();
+
+      await controller.testConnection(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.body).toEqual({ success: false, message: 'oauth_token_not_accepted' });
+    });
+
+    test('an Online request with no session at all gets 401 reauth_required', async () => {
+      const req: any = {
+        body: { siteUrl: 'https://tenant.sharepoint.com/:f:/r/x', library: '', folder: '' },
+      };
+      const res = buildRes();
+
+      await controller.testConnection(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.body).toEqual({ success: false, message: 'reauth_required' });
+      expect(mockSvc.testConnection).not.toHaveBeenCalled();
+    });
+
+    test('an Online request with a session uses a fresh GraphTokenProvider, never a client-supplied token', async () => {
+      const { createTokenProvider } = require('../../services/auth/MsalClientService');
+      const req: any = {
+        body: { siteUrl: 'https://tenant.sharepoint.com/:f:/r/x', library: '', folder: '' },
+        spSession: { homeAccountId: 'home-1' },
+      };
+      const res = buildRes();
+      mockSvc.testConnection.mockResolvedValueOnce({ success: true });
+
+      await controller.testConnection(req, res);
+
+      expect(createTokenProvider).toHaveBeenCalledWith('home-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test('on-prem requests are unaffected — still just need credentials, no session required', async () => {
+      const req: any = {
+        body: {
+          siteUrl: 'http://sp-server/sites/project',
+          library: 'l',
+          folder: 'f',
+          credentials: { username: 'u', password: 'p' },
+        },
+      };
+      const res = buildRes();
+      mockSvc.testConnection.mockResolvedValueOnce({ success: true });
+
+      await controller.testConnection(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockSvc.testConnection).toHaveBeenCalledWith(expect.anything(), { username: 'u', password: 'p' });
+    });
+
+    test('an on-prem request with no credentials and no session still gets Missing required fields, not reauth_required', async () => {
+      const req: any = {
+        body: { siteUrl: 'http://sp-server/sites/project', library: 'l', folder: 'f' },
+      };
+      const res = buildRes();
+
+      await controller.testConnection(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.body).toEqual({ success: false, message: 'Missing required fields' });
     });
   });
 
@@ -207,7 +303,7 @@ describe('SharePointController', () => {
       const res = buildRes();
       mockSvc.listTemplateFiles.mockResolvedValueOnce({ files: [{ name: 'a' }], truncated: false });
       await controller.listFiles(
-        { body: { siteUrl: 'u', library: 'l', folder: 'f', oauthToken: { accessToken: 't' } } } as any,
+        { body: { siteUrl: 'u', library: 'l', folder: 'f', credentials: { username: 'u', password: 'p' } } } as any,
         res
       );
       expect(res.status).toHaveBeenCalledWith(200);
@@ -218,7 +314,7 @@ describe('SharePointController', () => {
       const res = buildRes();
       mockSvc.listTemplateFiles.mockRejectedValueOnce(new Error('list-fail'));
       await controller.listFiles(
-        { body: { siteUrl: 'u', library: 'l', folder: 'f', oauthToken: { accessToken: 't' } } } as any,
+        { body: { siteUrl: 'u', library: 'l', folder: 'f', credentials: { username: 'u', password: 'p' } } } as any,
         res
       );
       expect(res.status).toHaveBeenCalledWith(500);
@@ -233,7 +329,7 @@ describe('SharePointController', () => {
       expiredTokenError.status = 401;
       mockSvc.listTemplateFiles.mockRejectedValueOnce(expiredTokenError);
       await controller.listFiles(
-        { body: { siteUrl: 'u', library: 'l', folder: 'f', oauthToken: { accessToken: 't' } } } as any,
+        { body: { siteUrl: 'u', library: 'l', folder: 'f', credentials: { username: 'u', password: 'p' } } } as any,
         res
       );
       expect(res.status).toHaveBeenCalledWith(401);
@@ -246,7 +342,7 @@ describe('SharePointController', () => {
     // Regression: this exact request shape (Online, no library/folder) was
     // silently rejected with 400 before the fix — the actual bug found when
     // testing the real "Sync from SharePoint" flow end to end.
-    test('200 with oauthToken even when library/folder are empty (Online config)', async () => {
+    test('200 with a session even when library/folder are empty (Online config)', async () => {
       const res = buildRes();
       mockSvc.listTemplateFiles.mockResolvedValueOnce({ files: [{ name: 'SVD-template.docx' }], truncated: false });
       await controller.listFiles(
@@ -255,8 +351,8 @@ describe('SharePointController', () => {
             siteUrl: 'https://tenant.sharepoint.com/:f:/r/teams/x/Shared Documents/DocGen Templates',
             library: '',
             folder: '',
-            oauthToken: { accessToken: 't' },
           },
+          spSession: { homeAccountId: 'home-1' },
         } as any,
         res
       );
@@ -301,7 +397,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'shared',
           },
@@ -336,7 +432,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -366,7 +462,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -391,7 +487,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -430,7 +526,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -466,7 +562,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -493,7 +589,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -520,7 +616,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -543,7 +639,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -576,7 +672,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'shared',
           },
@@ -617,7 +713,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -656,7 +752,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -690,7 +786,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -722,7 +818,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -751,7 +847,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -784,7 +880,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -810,7 +906,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -835,7 +931,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -860,7 +956,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -888,7 +984,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -909,7 +1005,7 @@ describe('SharePointController', () => {
             siteUrl: 'u',
             library: 'l',
             folder: 'f',
-            oauthToken: { accessToken: 't' },
+            credentials: { username: 'u', password: 'p' },
             bucketName: 'templates',
             projectName: 'project',
           },
@@ -1129,6 +1225,74 @@ describe('SharePointController', () => {
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.body.success).toBe(true);
       expect(__mockConfigModel.findOne).toHaveBeenCalledWith({ userId: 'u1' });
+    });
+
+    test('getConfig: flags a legacy Online row (populated library/folder) as requiresRelink', async () => {
+      const { __mockConfigModel } = require('../../models/SharePointConfig');
+      __mockConfigModel.findOne.mockImplementationOnce(() => ({
+        sort: jest.fn().mockResolvedValue({
+          userId: 'u1',
+          siteUrl: 'https://tenant.sharepoint.com/sites/projectx',
+          library: 'Shared Documents',
+          folder: 'Templates/STD',
+          save: jest.fn().mockResolvedValue(null),
+        }),
+      }));
+      const res = buildRes();
+      await controller.getConfig({ headers: { 'x-user-id': 'u1' }, query: {} } as any, res);
+      expect(res.body.requiresRelink).toBe(true);
+      expect(res.body.relinkReason).toBe('legacy-site-path');
+    });
+
+    test('getConfig: does not flag a Copy-Link-shaped Online row', async () => {
+      const { __mockConfigModel } = require('../../models/SharePointConfig');
+      __mockConfigModel.findOne.mockImplementationOnce(() => ({
+        sort: jest.fn().mockResolvedValue({
+          userId: 'u1',
+          siteUrl: 'https://tenant.sharepoint.com/:f:/r/teams/x/Shared%20Documents/y',
+          save: jest.fn().mockResolvedValue(null),
+        }),
+      }));
+      const res = buildRes();
+      await controller.getConfig({ headers: { 'x-user-id': 'u1' }, query: {} } as any, res);
+      expect(res.body.requiresRelink).toBe(false);
+      expect(res.body.relinkReason).toBeNull();
+    });
+
+    test('getConfig: does not flag an on-prem row', async () => {
+      const { __mockConfigModel } = require('../../models/SharePointConfig');
+      __mockConfigModel.findOne.mockImplementationOnce(() => ({
+        sort: jest.fn().mockResolvedValue({
+          userId: 'u1',
+          siteUrl: 'http://sp-server/sites/project',
+          library: 'Templates',
+          folder: 'DocGen',
+          save: jest.fn().mockResolvedValue(null),
+        }),
+      }));
+      const res = buildRes();
+      await controller.getConfig({ headers: { 'x-user-id': 'u1' }, query: {} } as any, res);
+      expect(res.body.requiresRelink).toBe(false);
+    });
+
+    test('getConfig: trusts an already-confirmed row (authType + linkResolvedAt present) without reclassifying', async () => {
+      const { __mockConfigModel } = require('../../models/SharePointConfig');
+      __mockConfigModel.findOne.mockImplementationOnce(() => ({
+        sort: jest.fn().mockResolvedValue({
+          userId: 'u1',
+          // This siteUrl shape would otherwise classify as legacy — but a
+          // prior confirmed resolution should be trusted over the heuristic.
+          siteUrl: 'https://tenant.sharepoint.com/sites/projectx',
+          library: 'Shared Documents',
+          folder: 'Templates/STD',
+          authType: 'online',
+          linkResolvedAt: new Date(),
+          save: jest.fn().mockResolvedValue(null),
+        }),
+      }));
+      const res = buildRes();
+      await controller.getConfig({ headers: { 'x-user-id': 'u1' }, query: {} } as any, res);
+      expect(res.body.requiresRelink).toBe(false);
     });
 
     /**

--- a/src/test/helpers/auth/attachSessionIfPresent.test.ts
+++ b/src/test/helpers/auth/attachSessionIfPresent.test.ts
@@ -1,0 +1,64 @@
+jest.mock('../../../services/auth/SessionService', () => ({
+  __esModule: true,
+  resolveSession: jest.fn(),
+}));
+
+import { resolveSession } from '../../../services/auth/SessionService';
+import { attachSessionIfPresent } from '../../../helpers/auth/attachSessionIfPresent';
+import { sessionCookieName } from '../../../util/cookies';
+
+const mockResolveSession = resolveSession as jest.Mock;
+
+describe('attachSessionIfPresent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('calls next() without a session when no Authorization header or cookie is present — never blocks', async () => {
+    const req: any = { headers: {} };
+    const next = jest.fn();
+
+    await attachSessionIfPresent(req, {} as any, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.spSession).toBeUndefined();
+    expect(mockResolveSession).not.toHaveBeenCalled();
+  });
+
+  test('calls next() without a session when the token does not resolve to a live session — still never blocks', async () => {
+    mockResolveSession.mockResolvedValueOnce(null);
+    const req: any = { headers: { authorization: 'Bearer expired-token' } };
+    const next = jest.fn();
+
+    await attachSessionIfPresent(req, {} as any, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.spSession).toBeUndefined();
+  });
+
+  test('attaches spSession/spSessionRawToken and calls next() when a bearer token resolves', async () => {
+    const session = { sessionId: 's1', homeAccountId: 'h1', transport: 'bearer' };
+    mockResolveSession.mockResolvedValueOnce(session);
+    const req: any = { headers: { authorization: 'Bearer the-raw-token' } };
+    const next = jest.fn();
+
+    await attachSessionIfPresent(req, {} as any, next);
+
+    expect(req.spSession).toEqual(session);
+    expect(req.spSessionRawToken).toBe('the-raw-token');
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('falls back to the session cookie and attaches spSession when no Authorization header is present', async () => {
+    const session = { sessionId: 's1', homeAccountId: 'h1', transport: 'cookie' };
+    mockResolveSession.mockResolvedValueOnce(session);
+    const req: any = { headers: { cookie: `${sessionCookieName}=cookie-token-value` } };
+    const next = jest.fn();
+
+    await attachSessionIfPresent(req, {} as any, next);
+
+    expect(mockResolveSession).toHaveBeenCalledWith('cookie-token-value');
+    expect(req.spSession).toEqual(session);
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/src/test/helpers/auth/requireCsrf.test.ts
+++ b/src/test/helpers/auth/requireCsrf.test.ts
@@ -1,0 +1,137 @@
+jest.mock('../../../services/auth/SessionService', () => ({
+  __esModule: true,
+  verifyCsrf: jest.fn(),
+}));
+jest.mock('../../../util/authConfig', () => ({
+  __esModule: true,
+  getAllowedOrigins: jest.fn(),
+}));
+
+import { verifyCsrf } from '../../../services/auth/SessionService';
+import { getAllowedOrigins } from '../../../util/authConfig';
+import { requireCsrf } from '../../../helpers/auth/requireCsrf';
+import { buildRes } from '../../utils/testResponse';
+
+const mockVerifyCsrf = verifyCsrf as jest.Mock;
+const mockGetAllowedOrigins = getAllowedOrigins as jest.Mock;
+
+describe('requireCsrf', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAllowedOrigins.mockReturnValue(['https://docgen.example.com']);
+  });
+
+  test('skips entirely when there is no session at all (on-prem NTLM call — never has one)', async () => {
+    const req: any = { headers: {} };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await requireCsrf(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(mockGetAllowedOrigins).not.toHaveBeenCalled();
+    expect(mockVerifyCsrf).not.toHaveBeenCalled();
+  });
+
+  test('rejects a request with no Origin header at all', async () => {
+    const req: any = { headers: {}, spSession: { transport: 'cookie' } };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await requireCsrf(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ success: false, error: 'csrf_origin_missing' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('rejects an Origin not present in the allowlist', async () => {
+    const req: any = { headers: { origin: 'https://untrusted.example.com' }, spSession: { transport: 'cookie' } };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await requireCsrf(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ success: false, error: 'csrf_origin_not_allowed' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('treats a getAllowedOrigins() failure as an empty allowlist (fail closed)', async () => {
+    mockGetAllowedOrigins.mockImplementationOnce(() => {
+      throw new Error('CORS_ALLOWED_ORIGINS misconfigured');
+    });
+    const req: any = { headers: { origin: 'https://docgen.example.com' }, spSession: { transport: 'cookie' } };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await requireCsrf(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  describe('bearer transport', () => {
+    test('skips the CSRF-token check entirely once the Origin allowlist passes', async () => {
+      const req: any = { headers: { origin: 'https://docgen.example.com' }, spSession: { transport: 'bearer' } };
+      const res = buildRes();
+      const next = jest.fn();
+
+      await requireCsrf(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(mockVerifyCsrf).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cookie transport', () => {
+    test('rejects when the X-Csrf-Token header is missing', async () => {
+      const req: any = {
+        headers: { origin: 'https://docgen.example.com' },
+        spSession: { transport: 'cookie' },
+        spSessionRawToken: 'raw-session-token',
+      };
+      const res = buildRes();
+      const next = jest.fn();
+
+      await requireCsrf(req, res, next);
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body).toEqual({ success: false, error: 'csrf_token_missing' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    test('rejects when verifyCsrf reports a mismatch', async () => {
+      mockVerifyCsrf.mockResolvedValueOnce(false);
+      const req: any = {
+        headers: { origin: 'https://docgen.example.com', 'x-csrf-token': 'wrong-token' },
+        spSession: { transport: 'cookie' },
+        spSessionRawToken: 'raw-session-token',
+      };
+      const res = buildRes();
+      const next = jest.fn();
+
+      await requireCsrf(req, res, next);
+
+      expect(mockVerifyCsrf).toHaveBeenCalledWith('raw-session-token', 'wrong-token');
+      expect(res.statusCode).toBe(403);
+      expect(res.body).toEqual({ success: false, error: 'csrf_token_invalid' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    test('calls next() when the CSRF token verifies', async () => {
+      mockVerifyCsrf.mockResolvedValueOnce(true);
+      const req: any = {
+        headers: { origin: 'https://docgen.example.com', 'x-csrf-token': 'correct-token' },
+        spSession: { transport: 'cookie' },
+        spSessionRawToken: 'raw-session-token',
+      };
+      const res = buildRes();
+      const next = jest.fn();
+
+      await requireCsrf(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/test/helpers/auth/requireSession.test.ts
+++ b/src/test/helpers/auth/requireSession.test.ts
@@ -1,0 +1,93 @@
+jest.mock('../../../services/auth/SessionService', () => ({
+  __esModule: true,
+  resolveSession: jest.fn(),
+}));
+
+import { resolveSession } from '../../../services/auth/SessionService';
+import { requireSession } from '../../../helpers/auth/requireSession';
+import { buildRes } from '../../utils/testResponse';
+import { sessionCookieName } from '../../../util/cookies';
+
+const mockResolveSession = resolveSession as jest.Mock;
+
+describe('requireSession', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('responds 401 reauth_required when neither an Authorization header nor a session cookie is present', async () => {
+    const req: any = { headers: {} };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await requireSession(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ success: false, error: 'reauth_required' });
+    expect(next).not.toHaveBeenCalled();
+    expect(mockResolveSession).not.toHaveBeenCalled();
+  });
+
+  test('prefers the Authorization: Bearer header over a cookie when both are present', async () => {
+    mockResolveSession.mockResolvedValueOnce({ sessionId: 's1', homeAccountId: 'h1', transport: 'bearer' });
+    const req: any = {
+      headers: { authorization: 'Bearer bearer-token-value', cookie: `${sessionCookieName}=cookie-token-value` },
+    };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await requireSession(req, res, next);
+
+    expect(mockResolveSession).toHaveBeenCalledWith('bearer-token-value');
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('falls back to the session cookie when no Authorization header is present', async () => {
+    mockResolveSession.mockResolvedValueOnce({ sessionId: 's1', homeAccountId: 'h1', transport: 'cookie' });
+    const req: any = { headers: { cookie: `${sessionCookieName}=cookie-token-value; other=x` } };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await requireSession(req, res, next);
+
+    expect(mockResolveSession).toHaveBeenCalledWith('cookie-token-value');
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('responds 401 when the resolved token does not map to a live session', async () => {
+    mockResolveSession.mockResolvedValueOnce(null);
+    const req: any = { headers: { authorization: 'Bearer expired-token' } };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await requireSession(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ success: false, error: 'reauth_required' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('attaches spSession and spSessionRawToken to the request on success', async () => {
+    const session = { sessionId: 's1', homeAccountId: 'h1', transport: 'cookie' };
+    mockResolveSession.mockResolvedValueOnce(session);
+    const req: any = { headers: { authorization: 'Bearer the-raw-token' } };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await requireSession(req, res, next);
+
+    expect(req.spSession).toEqual(session);
+    expect(req.spSessionRawToken).toBe('the-raw-token');
+  });
+
+  test('ignores a malformed Authorization header that does not start with "Bearer "', async () => {
+    const req: any = { headers: { authorization: 'Basic something' } };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await requireSession(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(mockResolveSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/models/AuthSession.test.ts
+++ b/src/test/models/AuthSession.test.ts
@@ -1,0 +1,70 @@
+import { AuthSession } from '../../models/AuthSession';
+
+describe('AuthSession schema', () => {
+  const validFields = {
+    sessionTokenHash: 'hash-of-session-token',
+    homeAccountId: 'home-account-id-123',
+    transport: 'cookie',
+    csrfTokenHash: 'hash-of-csrf-token',
+    idleExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    absoluteExpiresAt: new Date(Date.now() + 8 * 60 * 60 * 1000),
+  };
+
+  test('validates with all required fields present', () => {
+    const doc = new AuthSession(validFields);
+    expect(doc.validateSync()).toBeUndefined();
+  });
+
+  test('validates without the optional ID-token-derived fields', () => {
+    const doc = new AuthSession(validFields);
+    expect(doc.displayName).toBeUndefined();
+    expect(doc.userPrincipalName).toBeUndefined();
+    expect(doc.tenantId).toBeUndefined();
+    expect(doc.validateSync()).toBeUndefined();
+  });
+
+  test('accepts the optional ID-token-derived fields when present', () => {
+    const doc = new AuthSession({
+      ...validFields,
+      displayName: 'Eden Zvi Schwartz',
+      userPrincipalName: 'eden@korentec.onmicrosoft.com',
+      tenantId: 'tenant-guid',
+    });
+    expect(doc.validateSync()).toBeUndefined();
+  });
+
+  test('defaults lastSeenAt to now when not supplied', () => {
+    const doc = new AuthSession(validFields);
+    expect(doc.lastSeenAt).toBeInstanceOf(Date);
+  });
+
+  test.each(['sessionTokenHash', 'homeAccountId', 'transport', 'csrfTokenHash', 'idleExpiresAt', 'absoluteExpiresAt'])(
+    'fails validation when %s is missing',
+    (field) => {
+      const fields = { ...validFields } as any;
+      delete fields[field];
+      const doc = new AuthSession(fields);
+      const error = doc.validateSync();
+      expect(error).toBeDefined();
+      expect(error?.errors[field]).toBeDefined();
+    }
+  );
+
+  test('rejects a transport value outside the cookie/bearer enum', () => {
+    const doc = new AuthSession({ ...validFields, transport: 'websocket' });
+    const error = doc.validateSync();
+    expect(error?.errors.transport).toBeDefined();
+  });
+
+  test('declares a TTL index on absoluteExpiresAt', () => {
+    const indexes = AuthSession.schema.indexes() as any[];
+    const ttlIndex = indexes.find((entry) => Object.prototype.hasOwnProperty.call(entry[0], 'absoluteExpiresAt'));
+    expect(ttlIndex?.[1]).toMatchObject({ expireAfterSeconds: 0 });
+  });
+
+  test('declares an index on homeAccountId (the MSAL cache partition key lookup path)', () => {
+    const indexes = AuthSession.schema.indexes() as any[];
+    const homeAccountIndex = indexes.find((entry) => Object.prototype.hasOwnProperty.call(entry[0], 'homeAccountId'));
+    expect(homeAccountIndex).toBeDefined();
+  });
+});

--- a/src/test/models/MsalTokenCache.test.ts
+++ b/src/test/models/MsalTokenCache.test.ts
@@ -1,0 +1,50 @@
+import { MsalTokenCache } from '../../models/MsalTokenCache';
+
+describe('MsalTokenCache schema', () => {
+  const validFields = {
+    homeAccountId: 'home-account-id-123',
+    ciphertext: 'base64-ciphertext',
+    iv: 'base64-iv',
+    authTag: 'base64-authtag',
+    expiresAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+  };
+
+  test('validates with all required fields present', () => {
+    const doc = new MsalTokenCache(validFields);
+    expect(doc.validateSync()).toBeUndefined();
+  });
+
+  test('defaults keyVersion to 1 when not supplied', () => {
+    const doc = new MsalTokenCache(validFields);
+    expect(doc.keyVersion).toBe(1);
+  });
+
+  test('accepts an explicit keyVersion for rotation', () => {
+    const doc = new MsalTokenCache({ ...validFields, keyVersion: 2 });
+    expect(doc.keyVersion).toBe(2);
+    expect(doc.validateSync()).toBeUndefined();
+  });
+
+  test.each(['homeAccountId', 'ciphertext', 'iv', 'authTag', 'expiresAt'])(
+    'fails validation when %s is missing',
+    (field) => {
+      const fields = { ...validFields } as any;
+      delete fields[field];
+      const doc = new MsalTokenCache(fields);
+      const error = doc.validateSync();
+      expect(error).toBeDefined();
+      expect(error?.errors[field]).toBeDefined();
+    }
+  );
+
+  test('declares a unique index on homeAccountId (one cache row per user)', () => {
+    const pathIsUnique = (MsalTokenCache.schema.path('homeAccountId') as any)?.options?.unique;
+    expect(pathIsUnique).toBe(true);
+  });
+
+  test('declares a TTL index on expiresAt', () => {
+    const indexes = MsalTokenCache.schema.indexes() as any[];
+    const ttlIndex = indexes.find((entry) => Object.prototype.hasOwnProperty.call(entry[0], 'expiresAt'));
+    expect(ttlIndex?.[1]).toMatchObject({ expireAfterSeconds: 0 });
+  });
+});

--- a/src/test/models/OAuthTransaction.test.ts
+++ b/src/test/models/OAuthTransaction.test.ts
@@ -1,0 +1,57 @@
+import { OAuthTransaction } from '../../models/OAuthTransaction';
+
+describe('OAuthTransaction schema', () => {
+  const validFields = {
+    state: 'state-123',
+    codeVerifier: 'verifier-456',
+    nonce: 'nonce-789',
+    openerOrigin: 'https://docgen.example.com',
+    transport: 'cookie',
+    expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+  };
+
+  test('validates with all required fields present', () => {
+    const doc = new OAuthTransaction(validFields);
+    expect(doc.validateSync()).toBeUndefined();
+  });
+
+  test.each(['state', 'codeVerifier', 'nonce', 'openerOrigin', 'transport', 'expiresAt'])(
+    'fails validation when %s is missing',
+    (field) => {
+      const fields = { ...validFields } as any;
+      delete fields[field];
+      const doc = new OAuthTransaction(fields);
+      const error = doc.validateSync();
+      expect(error).toBeDefined();
+      expect(error?.errors[field]).toBeDefined();
+    }
+  );
+
+  test('rejects a transport value outside the cookie/bearer enum', () => {
+    const doc = new OAuthTransaction({ ...validFields, transport: 'websocket' });
+    const error = doc.validateSync();
+    expect(error).toBeDefined();
+    expect(error?.errors.transport).toBeDefined();
+  });
+
+  test('accepts "bearer" as a valid transport', () => {
+    const doc = new OAuthTransaction({ ...validFields, transport: 'bearer' });
+    expect(doc.validateSync()).toBeUndefined();
+  });
+
+  test('declares a TTL index on expiresAt', () => {
+    const indexes = OAuthTransaction.schema.indexes() as any[];
+    const ttlIndex = indexes.find((entry) => Object.prototype.hasOwnProperty.call(entry[0], 'expiresAt'));
+    expect(ttlIndex).toBeDefined();
+    expect(ttlIndex?.[1]).toMatchObject({ expireAfterSeconds: 0 });
+  });
+
+  test('declares a unique index on state', () => {
+    const indexes = OAuthTransaction.schema.indexes() as any[];
+    const stateIndex = indexes.find((entry) => Object.prototype.hasOwnProperty.call(entry[0], 'state'));
+    // `unique: true` on the path itself also registers a unique index —
+    // covered either via schema-level index() or the path option.
+    const pathIsUnique = (OAuthTransaction.schema.path('state') as any)?.options?.unique;
+    expect(stateIndex || pathIsUnique).toBeTruthy();
+  });
+});

--- a/src/test/models/SessionHandleCode.test.ts
+++ b/src/test/models/SessionHandleCode.test.ts
@@ -1,0 +1,44 @@
+import { SessionHandleCode } from '../../models/SessionHandleCode';
+
+describe('SessionHandleCode schema', () => {
+  const validFields = {
+    codeHash: 'hash-of-one-time-code',
+    sessionTokenCiphertext: 'base64-ciphertext',
+    sessionTokenIv: 'base64-iv',
+    sessionTokenAuthTag: 'base64-authtag',
+    expiresAt: new Date(Date.now() + 60 * 1000),
+  };
+
+  test('validates with all required fields present', () => {
+    const doc = new SessionHandleCode(validFields);
+    expect(doc.validateSync()).toBeUndefined();
+  });
+
+  test('defaults sessionTokenKeyVersion to 1 when not supplied', () => {
+    const doc = new SessionHandleCode(validFields);
+    expect(doc.sessionTokenKeyVersion).toBe(1);
+  });
+
+  test.each(['codeHash', 'sessionTokenCiphertext', 'sessionTokenIv', 'sessionTokenAuthTag', 'expiresAt'])(
+    'fails validation when %s is missing',
+    (field) => {
+      const fields = { ...validFields } as any;
+      delete fields[field];
+      const doc = new SessionHandleCode(fields);
+      const error = doc.validateSync();
+      expect(error).toBeDefined();
+      expect(error?.errors[field]).toBeDefined();
+    }
+  );
+
+  test('declares a unique index on codeHash', () => {
+    const pathIsUnique = (SessionHandleCode.schema.path('codeHash') as any)?.options?.unique;
+    expect(pathIsUnique).toBe(true);
+  });
+
+  test('declares a TTL index on expiresAt', () => {
+    const indexes = SessionHandleCode.schema.indexes() as any[];
+    const ttlIndex = indexes.find((entry) => Object.prototype.hasOwnProperty.call(entry[0], 'expiresAt'));
+    expect(ttlIndex?.[1]).toMatchObject({ expireAfterSeconds: 0 });
+  });
+});

--- a/src/test/models/SharePointConfig.test.ts
+++ b/src/test/models/SharePointConfig.test.ts
@@ -1,0 +1,45 @@
+import { SharePointConfig } from '../../models/SharePointConfig';
+
+describe('SharePointConfig schema', () => {
+  // Regression: Mongoose's built-in `required` validator on a String path
+  // rejects an explicit empty string as "missing" (a `default` only ever
+  // fills in `undefined`, never ''). library/folder previously had
+  // `required: true` — which meant saving an Online config (whole location
+  // in siteUrl, library/folder legitimately '') would fail validation with
+  // a 500 the very first time a user completed the Connect & Sync flow,
+  // even after the controller's own 400 checks were fixed. This is real
+  // Mongoose validator behavior, not something the controller's mocked
+  // tests can exercise, so it's verified directly against the schema here.
+  test('validates with library and folder both empty (Online config)', () => {
+    const doc = new SharePointConfig({
+      siteUrl: 'https://tenant.sharepoint.com/:f:/r/teams/x/Shared Documents/DocGen Templates',
+      library: '',
+      folder: '',
+    });
+
+    const error = doc.validateSync();
+
+    expect(error).toBeUndefined();
+  });
+
+  test('validates with library empty but folder set (on-prem paste-a-URL config)', () => {
+    const doc = new SharePointConfig({
+      siteUrl: 'http://sp-server/sites/project',
+      library: '',
+      folder: 'Shared Documents/Templates',
+    });
+
+    const error = doc.validateSync();
+
+    expect(error).toBeUndefined();
+  });
+
+  test('still fails validation when siteUrl itself is missing', () => {
+    const doc = new SharePointConfig({ library: '', folder: '' });
+
+    const error = doc.validateSync();
+
+    expect(error).toBeDefined();
+    expect(error?.errors.siteUrl).toBeDefined();
+  });
+});

--- a/src/test/models/SharePointResolvedRoot.test.ts
+++ b/src/test/models/SharePointResolvedRoot.test.ts
@@ -1,0 +1,62 @@
+import { SharePointResolvedRoot } from '../../models/SharePointResolvedRoot';
+
+describe('SharePointResolvedRoot schema', () => {
+  const validFields = {
+    homeAccountId: 'home-account-id-123',
+    shareUrlHash: 'hash-of-sharing-url',
+    driveId: 'drive-abc',
+    itemId: 'item-def',
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  };
+
+  test('validates with all required fields present', () => {
+    const doc = new SharePointResolvedRoot(validFields);
+    expect(doc.validateSync()).toBeUndefined();
+  });
+
+  test('validates without the optional name field', () => {
+    const doc = new SharePointResolvedRoot(validFields);
+    expect(doc.name).toBeUndefined();
+    expect(doc.validateSync()).toBeUndefined();
+  });
+
+  test('accepts an optional name', () => {
+    const doc = new SharePointResolvedRoot({ ...validFields, name: 'DocGen Templates' });
+    expect(doc.validateSync()).toBeUndefined();
+  });
+
+  test('defaults resolvedAt to now when not supplied', () => {
+    const doc = new SharePointResolvedRoot(validFields);
+    expect(doc.resolvedAt).toBeInstanceOf(Date);
+  });
+
+  test.each(['homeAccountId', 'shareUrlHash', 'driveId', 'itemId', 'expiresAt'])(
+    'fails validation when %s is missing',
+    (field) => {
+      const fields = { ...validFields } as any;
+      delete fields[field];
+      const doc = new SharePointResolvedRoot(fields);
+      const error = doc.validateSync();
+      expect(error).toBeDefined();
+      expect(error?.errors[field]).toBeDefined();
+    }
+  );
+
+  test('declares a compound unique index on {homeAccountId, shareUrlHash} — one resolved root per user per link', () => {
+    const indexes = SharePointResolvedRoot.schema.indexes() as any[];
+    const compound = indexes.find(
+      (entry) =>
+        Object.prototype.hasOwnProperty.call(entry[0], 'homeAccountId') && Object.prototype.hasOwnProperty.call(entry[0], 'shareUrlHash')
+    );
+    expect(compound).toBeDefined();
+    expect(compound?.[1]).toMatchObject({ unique: true });
+  });
+
+  test('declares a TTL index on expiresAt', () => {
+    const indexes = SharePointResolvedRoot.schema.indexes() as any[];
+    const ttlIndex = indexes.find(
+      (entry) => Object.prototype.hasOwnProperty.call(entry[0], 'expiresAt') && !Object.prototype.hasOwnProperty.call(entry[0], 'homeAccountId')
+    );
+    expect(ttlIndex?.[1]).toMatchObject({ expireAfterSeconds: 0 });
+  });
+});

--- a/src/test/routes/JsonDocRoutes.test.ts
+++ b/src/test/routes/JsonDocRoutes.test.ts
@@ -607,26 +607,6 @@ describe('JsonDocRoutes', () => {
     expect(res.body).toEqual({ status: 404, message: 'download-not-found' });
   });
 
-  test('GET /minio/download forwards a structured controller error (status/code/dependency) instead of hardcoding 404', async () => {
-    const { app, routes } = createAppAndRoutes();
-    const structuredError: any = new Error('Failed to fetch templates/proj/STD/file.dotx from MinIO: AccessDenied');
-    structuredError.statusCode = 403;
-    structuredError.code = 'AccessDenied';
-    structuredError.dependency = 'minio';
-    (routes.minioController as any).downloadFile = jest.fn().mockRejectedValue(structuredError);
-
-    const res = await withLocalAgent(app, (agent) =>
-      agent.get('/minio/download/templates/proj/STD/file.dotx').expect(403)
-    );
-
-    expect(res.body).toEqual({
-      status: 403,
-      message: 'Failed to fetch templates/proj/STD/file.dotx from MinIO: AccessDenied',
-      code: 'AccessDenied',
-      dependency: 'minio',
-    });
-  });
-
   test('GET /dataBase/getFavorites returns 200 on success', async () => {
     const { app, routes } = createAppAndRoutes();
     (routes.dataBaseController as any).getFavorites = jest.fn().mockImplementation(async (_req, res) => {

--- a/src/test/routes/JsonDocRoutes.test.ts
+++ b/src/test/routes/JsonDocRoutes.test.ts
@@ -607,6 +607,26 @@ describe('JsonDocRoutes', () => {
     expect(res.body).toEqual({ status: 404, message: 'download-not-found' });
   });
 
+  test('GET /minio/download forwards a structured controller error (status/code/dependency) instead of hardcoding 404', async () => {
+    const { app, routes } = createAppAndRoutes();
+    const structuredError: any = new Error('Failed to fetch templates/proj/STD/file.dotx from MinIO: AccessDenied');
+    structuredError.statusCode = 403;
+    structuredError.code = 'AccessDenied';
+    structuredError.dependency = 'minio';
+    (routes.minioController as any).downloadFile = jest.fn().mockRejectedValue(structuredError);
+
+    const res = await withLocalAgent(app, (agent) =>
+      agent.get('/minio/download/templates/proj/STD/file.dotx').expect(403)
+    );
+
+    expect(res.body).toEqual({
+      status: 403,
+      message: 'Failed to fetch templates/proj/STD/file.dotx from MinIO: AccessDenied',
+      code: 'AccessDenied',
+      dependency: 'minio',
+    });
+  });
+
   test('GET /dataBase/getFavorites returns 200 on success', async () => {
     const { app, routes } = createAppAndRoutes();
     (routes.dataBaseController as any).getFavorites = jest.fn().mockImplementation(async (_req, res) => {
@@ -736,6 +756,9 @@ describe('JsonDocRoutes', () => {
     sp.getAllConfigs = jest.fn().mockImplementation(async (_req, res) => {
       res.status(200).json({ ok: 'getAllConfigs' });
     });
+    sp.resolveUrl = jest.fn().mockImplementation(async (_req, res) => {
+      res.status(200).json({ ok: 'resolveUrl' });
+    });
 
     await withLocalAgent(app, async (agent) => {
       await agent.post('/sharepoint/test-connection').expect(200);
@@ -747,6 +770,7 @@ describe('JsonDocRoutes', () => {
       await agent.delete('/sharepoint/config').expect(200);
       await agent.get('/sharepoint/configs').expect(200);
       await agent.get('/sharepoint/configs/all').expect(200);
+      await agent.post('/sharepoint/resolve-url').expect(200);
     });
 
     expect(sp.testConnection).toHaveBeenCalled();
@@ -758,5 +782,6 @@ describe('JsonDocRoutes', () => {
     expect(sp.deleteConfig).toHaveBeenCalled();
     expect(sp.getConfigs).toHaveBeenCalled();
     expect(sp.getAllConfigs).toHaveBeenCalled();
+    expect(sp.resolveUrl).toHaveBeenCalled();
   });
 });

--- a/src/test/routes/JsonDocRoutes.test.ts
+++ b/src/test/routes/JsonDocRoutes.test.ts
@@ -764,4 +764,82 @@ describe('JsonDocRoutes', () => {
     expect(sp.getAllConfigs).toHaveBeenCalled();
     expect(sp.resolveUrl).toHaveBeenCalled();
   });
+
+  describe('CORS fail-closed behavior', () => {
+    const previousCorsEnv = process.env.CORS_ALLOWED_ORIGINS;
+
+    afterEach(() => {
+      if (previousCorsEnv === undefined) {
+        delete process.env.CORS_ALLOWED_ORIGINS;
+      } else {
+        process.env.CORS_ALLOWED_ORIGINS = previousCorsEnv;
+      }
+    });
+
+    // Regression: this codebase previously treated an unset
+    // CORS_ALLOWED_ORIGINS as "allow every origin" (reflecting whatever
+    // Origin header the request carried). That default became a
+    // session-theft hole once credentials:true was added for the new
+    // SharePoint OAuth session cookie — a cross-origin page could otherwise
+    // ride an authenticated user's session. It must now deny by default.
+    test('blocks a cross-origin request when CORS_ALLOWED_ORIGINS is unset', async () => {
+      delete process.env.CORS_ALLOWED_ORIGINS;
+      const { app } = createAppAndRoutes();
+
+      await withLocalAgent(app, async (agent) => {
+        const res = await agent.get('/jsonDocument').set('Origin', 'https://untrusted.example.com');
+        expect(res.status).toBe(500);
+        expect(res.headers['access-control-allow-origin']).toBeUndefined();
+      });
+    });
+
+    test('blocks an origin not present in the allowlist', async () => {
+      process.env.CORS_ALLOWED_ORIGINS = 'https://docgen.example.com';
+      const { app } = createAppAndRoutes();
+
+      await withLocalAgent(app, async (agent) => {
+        const res = await agent.get('/jsonDocument').set('Origin', 'https://untrusted.example.com');
+        expect(res.status).toBe(500);
+        expect(res.headers['access-control-allow-origin']).toBeUndefined();
+      });
+    });
+
+    test('allows an origin present in the allowlist and echoes it back with credentials enabled', async () => {
+      process.env.CORS_ALLOWED_ORIGINS = 'https://docgen.example.com';
+      const { app } = createAppAndRoutes();
+
+      await withLocalAgent(app, async (agent) => {
+        const res = await agent.get('/jsonDocument').set('Origin', 'https://docgen.example.com');
+        expect(res.status).toBe(200);
+        expect(res.headers['access-control-allow-origin']).toBe('https://docgen.example.com');
+        expect(res.headers['access-control-allow-credentials']).toBe('true');
+      });
+    });
+
+    test('still allows a request with no Origin header at all (server-to-server / curl)', async () => {
+      delete process.env.CORS_ALLOWED_ORIGINS;
+      const { app } = createAppAndRoutes();
+
+      await withLocalAgent(app, async (agent) => {
+        const res = await agent.get('/jsonDocument');
+        expect(res.status).toBe(200);
+      });
+    });
+
+    test('preflight succeeds for the Authorization and X-Csrf-Token headers needed by the new auth flow', async () => {
+      process.env.CORS_ALLOWED_ORIGINS = 'https://docgen.example.com';
+      const { app } = createAppAndRoutes();
+
+      await withLocalAgent(app, async (agent) => {
+        const res = await agent
+          .options('/sharepoint/list-files')
+          .set('Origin', 'https://docgen.example.com')
+          .set('Access-Control-Request-Method', 'POST')
+          .set('Access-Control-Request-Headers', 'Authorization, X-Csrf-Token');
+        expect(res.status).toBe(204);
+        expect(res.headers['access-control-allow-headers']).toEqual(expect.stringContaining('Authorization'));
+        expect(res.headers['access-control-allow-headers']).toEqual(expect.stringContaining('X-Csrf-Token'));
+      });
+    });
+  });
 });

--- a/src/test/server.test.ts
+++ b/src/test/server.test.ts
@@ -37,6 +37,26 @@ describe('server bootstrap', () => {
     process.env.MINIO_ROOT_PASSWORD = 'pass';
     process.env.MINIO_REGION = 'eu';
     process.env.MINIO_ENDPOINT = 'http://minio';
+    // Required by assertAuthConfig(), now called before connectToDatabase().
+    process.env.CLIENT_ID = 'client-123';
+    process.env.TENANT_ID = 'tenant-456';
+    process.env.CLIENT_SECRET = 'secret-789';
+    process.env.REDIRECT_URI = 'http://localhost:4000/auth/callback';
+    process.env.SESSION_SECRET = 'a'.repeat(32);
+  });
+
+  test('logs error and exits when the auth config is invalid, without attempting a DB connection', async () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as any);
+    delete process.env.CLIENT_SECRET;
+    const connectMock = getConnectMock();
+
+    await import('../server');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(connectMock).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
   });
 
   test('starts server after successful DB connection', async () => {

--- a/src/test/services/GraphSharePointService.test.ts
+++ b/src/test/services/GraphSharePointService.test.ts
@@ -110,8 +110,9 @@ describe('GraphSharePointService', () => {
         });
 
       const service = new GraphSharePointService();
-      const files = await service.listTemplateFiles(allItemsUrl, token);
+      const { files, truncated } = await service.listTemplateFiles(allItemsUrl, token);
 
+      expect(truncated).toBe(false);
       expect(files).toEqual([
         {
           name: 'SVD-template.docx',
@@ -120,6 +121,7 @@ describe('GraphSharePointService', () => {
           timeLastModified: '2024-01-01T00:00:00Z',
           length: 1234,
           docType: 'SVD',
+          relativePath: 'SVD/SVD-template.docx',
         },
       ]);
 
@@ -207,6 +209,7 @@ describe('GraphSharePointService', () => {
       expect(mockedAxios.get).toHaveBeenCalledWith(
         expect.stringMatching(/^https:\/\/graph\.microsoft\.com\/v1\.0\/shares\/u!/),
         {
+          timeout: 15000,
           headers: {
             Authorization: `Bearer ${token.accessToken}`,
             Prefer: 'redeemSharingLinkIfNecessary',
@@ -273,6 +276,75 @@ describe('GraphSharePointService', () => {
     });
   });
 
+  describe('get() throttle retry', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    // Drives fake timers forward while withThrottleRetry is awaiting sleep().
+    async function flushRetries() {
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+        jest.runAllTimers();
+      }
+    }
+
+    test('retries a thrown 429 and succeeds on the next attempt', async () => {
+      const throttled: any = new Error('Too Many Requests');
+      throttled.response = { status: 429, headers: { 'retry-after': '1' } };
+      mockedAxios.get.mockRejectedValueOnce(throttled).mockResolvedValueOnce({ data: { id: 'item1' } });
+
+      const service = new GraphSharePointService();
+      const promise = (service as any).get('https://graph.microsoft.com/v1.0/x', 'tok');
+      await flushRetries();
+      const result = await promise;
+
+      expect(result).toEqual({ data: { id: 'item1' } });
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not retry a 403 (a real permission error, not throttling) — maps it immediately', async () => {
+      const denied: any = new Error('Forbidden');
+      denied.response = { status: 403, headers: {} };
+      mockedAxios.get.mockRejectedValue(denied);
+
+      const service = new GraphSharePointService();
+      await expect((service as any).get('https://graph.microsoft.com/v1.0/x', 'tok')).rejects.toThrow(
+        'This token does not have permission to read this SharePoint folder'
+      );
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    });
+
+    test('gives up after retries are exhausted and still maps to the documented error message', async () => {
+      const throttled: any = new Error('Server Too Busy');
+      throttled.response = { status: 503, headers: {} };
+      mockedAxios.get.mockRejectedValue(throttled);
+
+      const service = new GraphSharePointService();
+      const promise = (service as any).get('https://graph.microsoft.com/v1.0/x', 'tok');
+      await flushRetries();
+
+      await expect(promise).rejects.toThrow('Microsoft Graph error: 503');
+      expect(mockedAxios.get.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    test('defaults a request timeout when calling axios', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: {} });
+
+      const service = new GraphSharePointService();
+      await (service as any).get('https://graph.microsoft.com/v1.0/x', 'tok');
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        'https://graph.microsoft.com/v1.0/x',
+        expect.objectContaining({ timeout: 15000 })
+      );
+    });
+  });
+
   describe('listTemplateFiles', () => {
     test('descends into folder children, filters .docx/.dotx, and tags each file with its parent folder as docType', async () => {
       mockedAxios.get
@@ -332,8 +404,9 @@ describe('GraphSharePointService', () => {
         });
 
       const service = new GraphSharePointService();
-      const files = await service.listTemplateFiles(shareUrl, token);
+      const { files, truncated } = await service.listTemplateFiles(shareUrl, token);
 
+      expect(truncated).toBe(false);
       expect(files).toEqual([
         {
           name: 'SVD-template.docx',
@@ -342,10 +415,12 @@ describe('GraphSharePointService', () => {
           timeLastModified: '2024-01-01T00:00:00Z',
           length: 1234,
           docType: 'SVD',
+          relativePath: 'SVD/SVD-template.docx',
         },
       ]);
-      // Only 2 calls: root children + SVD's children. _hidden and the plain
-      // file at the root must not trigger extra requests.
+      // Only 2 calls: root children + SVD's children. _hidden, the plain
+      // file at the root, and the driveId-less nested subfolder must not
+      // trigger extra requests.
       expect(mockedAxios.get).toHaveBeenCalledTimes(2);
     });
 
@@ -388,7 +463,7 @@ describe('GraphSharePointService', () => {
         });
 
       const service = new GraphSharePointService();
-      const files = await service.listTemplateFiles(shareUrl, token);
+      const { files } = await service.listTemplateFiles(shareUrl, token);
 
       expect(files).toHaveLength(1);
       expect(files[0].docType).toBe('STD');
@@ -397,6 +472,66 @@ describe('GraphSharePointService', () => {
         'https://graph.microsoft.com/v1.0/next-page',
         expect.anything()
       );
+    });
+
+    // A3: the BFS walk now fetches CONCURRENT_FOLDER_FETCHES folders at a
+    // time instead of one at a time. Uses mockImplementation keyed on the
+    // actual URL requested (not a fixed mockResolvedValueOnce queue) so the
+    // assertions hold regardless of which order the concurrent fetches
+    // actually settle in.
+    test('processes a wide batch of subfolders concurrently with deterministic, correctly-associated output', async () => {
+      const subfolderNames = ['F0', 'F1', 'F2', 'F3', 'F4', 'F5']; // 6 — spans 2 batches at CONCURRENT_FOLDER_FETCHES=4
+
+      mockedAxios.get.mockImplementation(async (url: string) => {
+        if (url.includes('/shares/')) {
+          return {
+            data: {
+              value: subfolderNames.map((name) => ({
+                id: `folder-${name}`,
+                name,
+                folder: {},
+                parentReference: { driveId: 'drive1' },
+              })),
+            },
+          };
+        }
+        for (const name of subfolderNames) {
+          if (url === `https://graph.microsoft.com/v1.0/drives/drive1/items/folder-${name}/children`) {
+            return {
+              data: {
+                value: [
+                  {
+                    id: `item-${name}`,
+                    name: `${name}-template.docx`,
+                    file: {},
+                    size: 10,
+                    lastModifiedDateTime: '2024-01-01T00:00:00Z',
+                    '@microsoft.graph.downloadUrl': `https://download.example/${name}`,
+                  },
+                ],
+              },
+            };
+          }
+        }
+        throw new Error(`Unexpected URL in test: ${url}`);
+      });
+
+      const service = new GraphSharePointService();
+      const { files, truncated } = await service.listTemplateFiles(shareUrl, token);
+
+      expect(truncated).toBe(false);
+      expect(files).toHaveLength(6);
+      // Deterministic: output must follow original queue (BFS) order, not
+      // whatever order the concurrent batch happened to settle in.
+      expect(files.map((f) => f.relativePath)).toEqual([
+        'F0/F0-template.docx',
+        'F1/F1-template.docx',
+        'F2/F2-template.docx',
+        'F3/F3-template.docx',
+        'F4/F4-template.docx',
+        'F5/F5-template.docx',
+      ]);
+      files.forEach((f, i) => expect(f.docType).toBe(subfolderNames[i]));
     });
 
     test('skips a file with no @microsoft.graph.downloadUrl rather than crashing', async () => {
@@ -413,7 +548,7 @@ describe('GraphSharePointService', () => {
         });
 
       const service = new GraphSharePointService();
-      const files = await service.listTemplateFiles(shareUrl, token);
+      const { files } = await service.listTemplateFiles(shareUrl, token);
 
       expect(files).toEqual([]);
     });
@@ -441,7 +576,7 @@ describe('GraphSharePointService', () => {
         });
 
       const service = new GraphSharePointService();
-      const files = await service.listTemplateFiles(shareUrl, token);
+      const { files } = await service.listTemplateFiles(shareUrl, token);
 
       expect(files).toEqual([]);
     });
@@ -469,7 +604,7 @@ describe('GraphSharePointService', () => {
         });
 
       const service = new GraphSharePointService();
-      const files = await service.listTemplateFiles(shareUrl, token);
+      const { files } = await service.listTemplateFiles(shareUrl, token);
 
       expect(files).toEqual([]);
       // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -483,10 +618,71 @@ describe('GraphSharePointService', () => {
       });
 
       const service = new GraphSharePointService();
-      const files = await service.listTemplateFiles(shareUrl, token);
+      const { files } = await service.listTemplateFiles(shareUrl, token);
 
       expect(files).toEqual([]);
       expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    });
+
+    test('skips a permission-denied subfolder (403) and keeps files already found elsewhere', async () => {
+      mockedAxios.get
+        // root children -> two subfolders
+        .mockResolvedValueOnce({
+          data: {
+            value: [
+              { id: 'folder-svd', name: 'SVD', folder: {}, parentReference: { driveId: 'drive1' } },
+              { id: 'folder-denied', name: 'Denied', folder: {}, parentReference: { driveId: 'drive1' } },
+            ],
+          },
+        })
+        // SVD's children -> one valid file
+        .mockResolvedValueOnce({
+          data: {
+            value: [
+              {
+                id: 'item1',
+                name: 'SVD-template.docx',
+                file: {},
+                size: 10,
+                lastModifiedDateTime: '2024-01-01T00:00:00Z',
+                '@microsoft.graph.downloadUrl': 'https://download.example/1',
+              },
+            ],
+          },
+        })
+        // Denied's children -> 403
+        .mockRejectedValueOnce({ response: { status: 403, headers: {} } });
+
+      const service = new GraphSharePointService();
+      const { files, skippedFolders } = await service.listTemplateFiles(shareUrl, token);
+
+      expect(files).toHaveLength(1);
+      expect(files[0].docType).toBe('SVD');
+      expect(skippedFolders).toEqual([
+        { relativePath: 'Denied', reason: 'This token does not have permission to read this SharePoint folder' },
+      ]);
+    });
+
+    test('a 401 is never tolerated — stays fatal even on a subfolder', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({
+          data: { value: [{ id: 'folder-svd', name: 'SVD', folder: {}, parentReference: { driveId: 'drive1' } }] },
+        })
+        .mockRejectedValueOnce({ response: { status: 401, headers: {} } });
+
+      const service = new GraphSharePointService();
+      await expect(service.listTemplateFiles(shareUrl, token)).rejects.toThrow(
+        'Graph access token expired or invalid — paste a fresh one'
+      );
+    });
+
+    test('a denied shared-folder root (depth 0) always aborts, never skips', async () => {
+      mockedAxios.get.mockRejectedValueOnce({ response: { status: 403, headers: {} } });
+
+      const service = new GraphSharePointService();
+      await expect(service.listTemplateFiles(shareUrl, token)).rejects.toThrow(
+        'This token does not have permission to read this SharePoint folder'
+      );
     });
   });
 

--- a/src/test/services/GraphSharePointService.test.ts
+++ b/src/test/services/GraphSharePointService.test.ts
@@ -1,0 +1,529 @@
+import axios from 'axios';
+import { GraphSharePointService } from '../../services/GraphSharePointService';
+import { SharePointOAuthToken } from '../../services/SharePointService';
+
+jest.mock('axios', () => ({ get: jest.fn() }));
+
+jest.mock('../../util/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const mockedAxios = axios as unknown as { get: jest.Mock };
+
+describe('GraphSharePointService', () => {
+  const shareUrl = 'https://tenant.sharepoint.com/:f:/s/site/shareToken?e=abc123';
+  const token: SharePointOAuthToken = { accessToken: 'graph-token' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('origin allowlist (encodeShareId)', () => {
+    test.each([
+      'https://tenant.sharepoint.com/:f:/s/site/token',
+      'https://tenant-my.sharepoint.com/personal/user/token',
+      'https://onedrive.live.com/redir?resid=abc',
+      'https://company.sharepoint.us/:f:/s/site/token',
+      'https://1drv.ms/f/s!abc123',
+    ])('accepts a real Microsoft sharing link: %s', async (url) => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { id: 'item1' } });
+      const service = new GraphSharePointService();
+
+      const result = await service.testShareAccess(url, token);
+
+      expect(result.success).toBe(true);
+    });
+
+    test.each([
+      'https://evil.example.com/steal-my-token',
+      'https://not-sharepoint.com/:f:/s/site/token',
+      'not-a-url-at-all',
+      '',
+    ])('rejects a non-Microsoft URL before any network call: %s', async (url) => {
+      const service = new GraphSharePointService();
+
+      const result = await service.testShareAccess(url, token);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('SharePoint or OneDrive link');
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
+
+    test('listTemplateFiles rejects a non-Microsoft URL before any network call too', async () => {
+      const service = new GraphSharePointService();
+
+      await expect(service.listTemplateFiles('https://evil.example.com/x', token)).rejects.toThrow(
+        'SharePoint or OneDrive link'
+      );
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('browsed AllItems.aspx folder URLs (path-based resolution, not /shares)', () => {
+    // Real production example: navigating into a folder and copying the
+    // address bar, rather than using "Copy Link", produces this shape — the
+    // real folder path lives in the `id=` query param, not the page path.
+    const allItemsUrl =
+      'https://tenant.sharepoint.com/teams/TeamName/Shared%20Documents/Forms/AllItems.aspx' +
+      '?csf=1&web=1&e=sess123&CID=abc-def&FolderCTID=0x012001' +
+      '&id=%2Fteams%2FTeamName%2FShared%20Documents%2FTraining%20and%20Templates%2FDocGen%20Templates';
+
+    test('walks the path from longest to shortest prefix to find the site, then resolves the folder within its drive', async () => {
+      mockedAxios.get
+        // segments: ['teams','TeamName','Shared Documents','Training and Templates','DocGen Templates']
+        // Longest candidate (all 5 segments) fails
+        .mockRejectedValueOnce({ response: { status: 404 } })
+        // 4 segments (.../Training and Templates) fails
+        .mockRejectedValueOnce({ response: { status: 404 } })
+        // 3 segments (.../Shared Documents) fails — a library isn't a site
+        .mockRejectedValueOnce({ response: { status: 404 } })
+        // 2 segments (.../teams/TeamName) resolves as the site
+        .mockResolvedValueOnce({ data: { id: 'site-id-1' } })
+        // remaining path resolved against that site's default drive
+        .mockResolvedValueOnce({
+          data: { id: 'folder-item-1', parentReference: { driveId: 'drive-1' } },
+        })
+        // root children of the resolved folder
+        .mockResolvedValueOnce({
+          data: {
+            value: [{ id: 'folder-svd', name: 'SVD', folder: {}, parentReference: { driveId: 'drive-1' } }],
+          },
+        })
+        // SVD's children
+        .mockResolvedValueOnce({
+          data: {
+            value: [
+              {
+                id: 'item1',
+                name: 'SVD-template.docx',
+                file: {},
+                size: 1234,
+                createdDateTime: '2023-12-01T00:00:00Z',
+                lastModifiedDateTime: '2024-01-01T00:00:00Z',
+                '@microsoft.graph.downloadUrl': 'https://download.example/1',
+              },
+            ],
+          },
+        });
+
+      const service = new GraphSharePointService();
+      const files = await service.listTemplateFiles(allItemsUrl, token);
+
+      expect(files).toEqual([
+        {
+          name: 'SVD-template.docx',
+          serverRelativeUrl: 'https://download.example/1',
+          timeCreated: '2023-12-01T00:00:00Z',
+          timeLastModified: '2024-01-01T00:00:00Z',
+          length: 1234,
+          docType: 'SVD',
+        },
+      ]);
+
+      // First call must have tried the site-by-path candidates before ever
+      // hitting /shares — confirms the AllItems.aspx shape never goes near
+      // the /shares endpoint at all.
+      const calledUrls = mockedAxios.get.mock.calls.map((call) => call[0]);
+      expect(calledUrls.every((url) => !url.includes('/shares/'))).toBe(true);
+      expect(calledUrls[3]).toContain('/sites/tenant.sharepoint.com:/teams/TeamName');
+      expect(calledUrls[4]).toContain('/sites/site-id-1/drive/root:/');
+      expect(calledUrls[4]).toContain('Shared%20Documents');
+    });
+
+    test('throws a clear error when no site is found anywhere along the path', async () => {
+      mockedAxios.get.mockRejectedValue({ response: { status: 404 } });
+
+      const service = new GraphSharePointService();
+
+      await expect(service.listTemplateFiles(allItemsUrl, token)).rejects.toThrow(
+        'Could not resolve a SharePoint site from this folder link'
+      );
+    });
+
+    test('throws a clear error when the whole path is the site itself (no folder remains)', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { id: 'site-id-1' } });
+
+      const service = new GraphSharePointService();
+      const siteOnlyUrl =
+        'https://tenant.sharepoint.com/teams/TeamName/Forms/AllItems.aspx?id=%2Fteams%2FTeamName';
+
+      await expect(service.listTemplateFiles(siteOnlyUrl, token)).rejects.toThrow(
+        'This link points to a site, not a folder inside a document library'
+      );
+    });
+
+    test('a 401/403 during the path walk surfaces immediately rather than being treated as "keep walking"', async () => {
+      mockedAxios.get.mockRejectedValueOnce({ response: { status: 401 } });
+
+      const service = new GraphSharePointService();
+
+      await expect(service.listTemplateFiles(allItemsUrl, token)).rejects.toThrow(
+        'Graph access token expired or invalid'
+      );
+      // Only one call — must not have continued walking after a real auth error.
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    });
+
+    // The thrown error must carry the real HTTP status so callers can
+    // respond 401 (an expired token is expected, not a server error)
+    // instead of an unconditional 500.
+    test('a 401 during the path walk carries status 401 on the thrown error', async () => {
+      mockedAxios.get.mockRejectedValueOnce({ response: { status: 401 } });
+
+      const service = new GraphSharePointService();
+
+      let caught: any;
+      try {
+        await service.listTemplateFiles(allItemsUrl, token);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught.status).toBe(401);
+    });
+
+    test('rejects a non-Microsoft hostname even in AllItems.aspx shape before any network call', async () => {
+      const service = new GraphSharePointService();
+      const evilUrl = 'https://evil.example.com/Shared%20Documents/Forms/AllItems.aspx?id=%2FShared%20Documents%2FX';
+
+      await expect(service.listTemplateFiles(evilUrl, token)).rejects.toThrow('SharePoint or OneDrive link');
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('testShareAccess', () => {
+    test('returns success when /shares/{id}/driveItem resolves', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { id: 'item1' } });
+
+      const service = new GraphSharePointService();
+      const result = await service.testShareAccess(shareUrl, token);
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Successfully connected to SharePoint via Microsoft Graph',
+      });
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        expect.stringMatching(/^https:\/\/graph\.microsoft\.com\/v1\.0\/shares\/u!/),
+        {
+          headers: {
+            Authorization: `Bearer ${token.accessToken}`,
+            Prefer: 'redeemSharingLinkIfNecessary',
+          },
+        }
+      );
+    });
+
+    test('sends Prefer: redeemSharingLinkIfNecessary — /shares needs this to fully resolve a link the caller has not "opened" before, even with sufficient token scope', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { id: 'item1' } });
+      const service = new GraphSharePointService();
+
+      await service.testShareAccess(shareUrl, token);
+
+      expect(mockedAxios.get.mock.calls[0][1].headers.Prefer).toBe('redeemSharingLinkIfNecessary');
+    });
+
+    test('maps a 401 to a token-expired message', async () => {
+      mockedAxios.get.mockRejectedValueOnce({ response: { status: 401 } });
+
+      const service = new GraphSharePointService();
+      const result = await service.testShareAccess(shareUrl, token);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('expired or invalid');
+    });
+
+    test('maps a 403 to a permission message', async () => {
+      mockedAxios.get.mockRejectedValueOnce({ response: { status: 403 } });
+
+      const service = new GraphSharePointService();
+      const result = await service.testShareAccess(shareUrl, token);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('permission');
+    });
+
+    // A 403/401 alone doesn't say which resolution step failed or what URL
+    // was tried — this was a real diagnosability gap when triaging a live
+    // failure. The URL (never the token) is logged so it's visible which
+    // Graph call actually failed.
+    test('logs the failing URL (not the token) on a Graph error response', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const logger = require('../../util/logger');
+      mockedAxios.get.mockRejectedValueOnce({ response: { status: 403 } });
+
+      const service = new GraphSharePointService();
+      await service.testShareAccess(shareUrl, token);
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Graph request failed (403)'));
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('/shares/'));
+      const loggedMessage = logger.warn.mock.calls.find((c: any) => c[0].includes('Graph request failed'))[0];
+      expect(loggedMessage).not.toContain(token.accessToken);
+    });
+
+    test('maps a transport-level failure (no response) to a reachability message', async () => {
+      mockedAxios.get.mockRejectedValueOnce(new Error('ECONNRESET'));
+
+      const service = new GraphSharePointService();
+      const result = await service.testShareAccess(shareUrl, token);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Could not reach Microsoft Graph');
+    });
+  });
+
+  describe('listTemplateFiles', () => {
+    test('descends into folder children, filters .docx/.dotx, and tags each file with its parent folder as docType', async () => {
+      mockedAxios.get
+        // /shares/{id}/driveItem/children -> subfolders
+        .mockResolvedValueOnce({
+          data: {
+            value: [
+              {
+                id: 'folder-svd',
+                name: 'SVD',
+                folder: {},
+                parentReference: { driveId: 'drive1' },
+              },
+              {
+                id: 'folder-hidden',
+                name: '_hidden',
+                folder: {},
+                parentReference: { driveId: 'drive1' },
+              },
+              {
+                id: 'file-not-a-folder',
+                name: 'readme.txt',
+                file: {},
+                parentReference: { driveId: 'drive1' },
+              },
+            ],
+          },
+        })
+        // /drives/drive1/items/folder-svd/children -> files in SVD
+        .mockResolvedValueOnce({
+          data: {
+            value: [
+              {
+                id: 'item1',
+                name: 'SVD-template.docx',
+                file: {},
+                size: 1234,
+                createdDateTime: '2023-12-01T00:00:00Z',
+                lastModifiedDateTime: '2024-01-01T00:00:00Z',
+                '@microsoft.graph.downloadUrl': 'https://download.example/1',
+              },
+              {
+                id: 'item2',
+                name: 'notes.txt',
+                file: {},
+                size: 99,
+                lastModifiedDateTime: '2024-01-02T00:00:00Z',
+                '@microsoft.graph.downloadUrl': 'https://download.example/2',
+              },
+              {
+                id: 'item3',
+                name: 'subfolder-in-svd',
+                folder: {},
+              },
+            ],
+          },
+        });
+
+      const service = new GraphSharePointService();
+      const files = await service.listTemplateFiles(shareUrl, token);
+
+      expect(files).toEqual([
+        {
+          name: 'SVD-template.docx',
+          serverRelativeUrl: 'https://download.example/1',
+          timeCreated: '2023-12-01T00:00:00Z',
+          timeLastModified: '2024-01-01T00:00:00Z',
+          length: 1234,
+          docType: 'SVD',
+        },
+      ]);
+      // Only 2 calls: root children + SVD's children. _hidden and the plain
+      // file at the root must not trigger extra requests.
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+    });
+
+    test('follows @odata.nextLink pagination', async () => {
+      mockedAxios.get
+        // page 1 of root children
+        .mockResolvedValueOnce({
+          data: {
+            value: [],
+            '@odata.nextLink': 'https://graph.microsoft.com/v1.0/next-page',
+          },
+        })
+        // page 2 of root children
+        .mockResolvedValueOnce({
+          data: {
+            value: [
+              {
+                id: 'folder-std',
+                name: 'STD',
+                folder: {},
+                parentReference: { driveId: 'drive1' },
+              },
+            ],
+          },
+        })
+        // STD's children
+        .mockResolvedValueOnce({
+          data: {
+            value: [
+              {
+                id: 'item1',
+                name: 'STD-template.dotx',
+                file: {},
+                size: 42,
+                lastModifiedDateTime: '2024-02-01T00:00:00Z',
+                '@microsoft.graph.downloadUrl': 'https://download.example/std',
+              },
+            ],
+          },
+        });
+
+      const service = new GraphSharePointService();
+      const files = await service.listTemplateFiles(shareUrl, token);
+
+      expect(files).toHaveLength(1);
+      expect(files[0].docType).toBe('STD');
+      expect(mockedAxios.get).toHaveBeenNthCalledWith(
+        2,
+        'https://graph.microsoft.com/v1.0/next-page',
+        expect.anything()
+      );
+    });
+
+    test('skips a file with no @microsoft.graph.downloadUrl rather than crashing', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({
+          data: {
+            value: [{ id: 'folder-svd', name: 'SVD', folder: {}, parentReference: { driveId: 'drive1' } }],
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            value: [{ id: 'item1', name: 'no-url.docx', file: {}, size: 1 }],
+          },
+        });
+
+      const service = new GraphSharePointService();
+      const files = await service.listTemplateFiles(shareUrl, token);
+
+      expect(files).toEqual([]);
+    });
+
+    test('excludes an Office lock/temp file (~$...) even though it ends in .docx', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({
+          data: {
+            value: [{ id: 'folder-svd', name: 'SVD', folder: {}, parentReference: { driveId: 'drive1' } }],
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            value: [
+              {
+                id: 'item1',
+                name: '~$ftware Version Description.dotx',
+                file: {},
+                size: 162,
+                lastModifiedDateTime: '2024-01-01T00:00:00Z',
+                '@microsoft.graph.downloadUrl': 'https://download.example/lockfile',
+              },
+            ],
+          },
+        });
+
+      const service = new GraphSharePointService();
+      const files = await service.listTemplateFiles(shareUrl, token);
+
+      expect(files).toEqual([]);
+    });
+
+    test('excludes a file over the max template size and logs why', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({
+          data: {
+            value: [{ id: 'folder-svd', name: 'SVD', folder: {}, parentReference: { driveId: 'drive1' } }],
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            value: [
+              {
+                id: 'item1',
+                name: 'huge-template.docx',
+                file: {},
+                size: 51 * 1024 * 1024,
+                lastModifiedDateTime: '2024-01-01T00:00:00Z',
+                '@microsoft.graph.downloadUrl': 'https://download.example/huge',
+              },
+            ],
+          },
+        });
+
+      const service = new GraphSharePointService();
+      const files = await service.listTemplateFiles(shareUrl, token);
+
+      expect(files).toEqual([]);
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const logger = require('../../util/logger');
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('exceeds the sync limit'));
+    });
+
+    test('skips a subfolder with no driveId/itemId rather than crashing', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { value: [{ id: undefined, name: 'SVD', folder: {}, parentReference: {} }] },
+      });
+
+      const service = new GraphSharePointService();
+      const files = await service.listTemplateFiles(shareUrl, token);
+
+      expect(files).toEqual([]);
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('downloadFile', () => {
+    test('fetches the pre-signed download URL with no Authorization header', async () => {
+      const payload = Buffer.from('file-bytes');
+      mockedAxios.get.mockResolvedValueOnce({ data: payload });
+
+      const service = new GraphSharePointService();
+      const result = await service.downloadFile('https://download.example/precise-url');
+
+      expect(mockedAxios.get).toHaveBeenCalledWith('https://download.example/precise-url', {
+        responseType: 'arraybuffer',
+      });
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(result.toString()).toBe('file-bytes');
+    });
+
+    test('refuses a non-https download URL', async () => {
+      const service = new GraphSharePointService();
+
+      await expect(service.downloadFile('http://download.example/precise-url')).rejects.toThrow(
+        'Refusing to fetch a non-https download URL'
+      );
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
+
+    test.each(['localhost', '127.0.0.1', '10.0.0.5', '172.16.0.1', '192.168.1.1', '169.254.1.1'])(
+      'refuses a download URL pointing at the private/internal host %s',
+      async (hostname) => {
+        const service = new GraphSharePointService();
+
+        await expect(service.downloadFile(`https://${hostname}/precise-url`)).rejects.toThrow(
+          'Refusing to fetch a download URL pointing at a private/internal host'
+        );
+        expect(mockedAxios.get).not.toHaveBeenCalled();
+      }
+    );
+  });
+});

--- a/src/test/services/GraphSharePointService.test.ts
+++ b/src/test/services/GraphSharePointService.test.ts
@@ -60,144 +60,108 @@ describe('GraphSharePointService', () => {
       );
       expect(mockedAxios.get).not.toHaveBeenCalled();
     });
-  });
 
-  describe('browsed AllItems.aspx folder URLs (path-based resolution, not /shares)', () => {
-    // Real production example: navigating into a folder and copying the
-    // address bar, rather than using "Copy Link", produces this shape — the
-    // real folder path lives in the `id=` query param, not the page path.
-    const allItemsUrl =
-      'https://tenant.sharepoint.com/teams/TeamName/Shared%20Documents/Forms/AllItems.aspx' +
-      '?csf=1&web=1&e=sess123&CID=abc-def&FolderCTID=0x012001' +
-      '&id=%2Fteams%2FTeamName%2FShared%20Documents%2FTraining%20and%20Templates%2FDocGen%20Templates';
-
-    test('walks the path from longest to shortest prefix to find the site, then resolves the folder within its drive', async () => {
-      mockedAxios.get
-        // segments: ['teams','TeamName','Shared Documents','Training and Templates','DocGen Templates']
-        // Longest candidate (all 5 segments) fails
-        .mockRejectedValueOnce({ response: { status: 404 } })
-        // 4 segments (.../Training and Templates) fails
-        .mockRejectedValueOnce({ response: { status: 404 } })
-        // 3 segments (.../Shared Documents) fails — a library isn't a site
-        .mockRejectedValueOnce({ response: { status: 404 } })
-        // 2 segments (.../teams/TeamName) resolves as the site
-        .mockResolvedValueOnce({ data: { id: 'site-id-1' } })
-        // remaining path resolved against that site's default drive
-        .mockResolvedValueOnce({
-          data: { id: 'folder-item-1', parentReference: { driveId: 'drive-1' } },
-        })
-        // root children of the resolved folder
-        .mockResolvedValueOnce({
-          data: {
-            value: [{ id: 'folder-svd', name: 'SVD', folder: {}, parentReference: { driveId: 'drive-1' } }],
-          },
-        })
-        // SVD's children
-        .mockResolvedValueOnce({
-          data: {
-            value: [
-              {
-                id: 'item1',
-                name: 'SVD-template.docx',
-                file: {},
-                size: 1234,
-                createdDateTime: '2023-12-01T00:00:00Z',
-                lastModifiedDateTime: '2024-01-01T00:00:00Z',
-                '@microsoft.graph.downloadUrl': 'https://download.example/1',
-              },
-            ],
-          },
-        });
-
-      const service = new GraphSharePointService();
-      const { files, truncated } = await service.listTemplateFiles(allItemsUrl, token);
-
-      expect(truncated).toBe(false);
-      expect(files).toEqual([
-        {
-          name: 'SVD-template.docx',
-          serverRelativeUrl: 'https://download.example/1',
-          timeCreated: '2023-12-01T00:00:00Z',
-          timeLastModified: '2024-01-01T00:00:00Z',
-          length: 1234,
-          docType: 'SVD',
-          relativePath: 'SVD/SVD-template.docx',
-        },
-      ]);
-
-      // First call must have tried the site-by-path candidates before ever
-      // hitting /shares — confirms the AllItems.aspx shape never goes near
-      // the /shares endpoint at all.
-      const calledUrls = mockedAxios.get.mock.calls.map((call) => call[0]);
-      expect(calledUrls.every((url) => !url.includes('/shares/'))).toBe(true);
-      expect(calledUrls[3]).toContain('/sites/tenant.sharepoint.com:/teams/TeamName');
-      expect(calledUrls[4]).toContain('/sites/site-id-1/drive/root:/');
-      expect(calledUrls[4]).toContain('Shared%20Documents');
-    });
-
-    test('throws a clear error when no site is found anywhere along the path', async () => {
-      mockedAxios.get.mockRejectedValue({ response: { status: 404 } });
-
+    test('resolveShareRoot rejects a non-Microsoft URL before any network call too', async () => {
       const service = new GraphSharePointService();
 
-      await expect(service.listTemplateFiles(allItemsUrl, token)).rejects.toThrow(
-        'Could not resolve a SharePoint site from this folder link'
+      await expect(service.resolveShareRoot('https://evil.example.com/x', token)).rejects.toThrow(
+        'SharePoint or OneDrive link'
       );
-    });
-
-    test('throws a clear error when the whole path is the site itself (no folder remains)', async () => {
-      mockedAxios.get.mockResolvedValueOnce({ data: { id: 'site-id-1' } });
-
-      const service = new GraphSharePointService();
-      const siteOnlyUrl =
-        'https://tenant.sharepoint.com/teams/TeamName/Forms/AllItems.aspx?id=%2Fteams%2FTeamName';
-
-      await expect(service.listTemplateFiles(siteOnlyUrl, token)).rejects.toThrow(
-        'This link points to a site, not a folder inside a document library'
-      );
-    });
-
-    test('a 401/403 during the path walk surfaces immediately rather than being treated as "keep walking"', async () => {
-      mockedAxios.get.mockRejectedValueOnce({ response: { status: 401 } });
-
-      const service = new GraphSharePointService();
-
-      await expect(service.listTemplateFiles(allItemsUrl, token)).rejects.toThrow(
-        'Graph access token expired or invalid'
-      );
-      // Only one call — must not have continued walking after a real auth error.
-      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
-    });
-
-    // The thrown error must carry the real HTTP status so callers can
-    // respond 401 (an expired token is expected, not a server error)
-    // instead of an unconditional 500.
-    test('a 401 during the path walk carries status 401 on the thrown error', async () => {
-      mockedAxios.get.mockRejectedValueOnce({ response: { status: 401 } });
-
-      const service = new GraphSharePointService();
-
-      let caught: any;
-      try {
-        await service.listTemplateFiles(allItemsUrl, token);
-      } catch (err) {
-        caught = err;
-      }
-      expect(caught.status).toBe(401);
-    });
-
-    test('rejects a non-Microsoft hostname even in AllItems.aspx shape before any network call', async () => {
-      const service = new GraphSharePointService();
-      const evilUrl = 'https://evil.example.com/Shared%20Documents/Forms/AllItems.aspx?id=%2FShared%20Documents%2FX';
-
-      await expect(service.listTemplateFiles(evilUrl, token)).rejects.toThrow('SharePoint or OneDrive link');
       expect(mockedAxios.get).not.toHaveBeenCalled();
     });
   });
 
-  describe('testShareAccess', () => {
-    test('returns success when /shares/{id}/driveItem resolves', async () => {
+  // Regression: a live spike this session proved /shares resolves BOTH a
+  // "Copy Link" sharing URL and a plain browsed-folder address-bar URL
+  // (the .../shared?id=%2Fsites%2F... shape) under Files.Read.All alone.
+  // GraphSharePointService no longer has a separate /sites/{hostname}:/{path}
+  // + /sites/{siteId}/drive/root:/{path}: resolution path — every Online
+  // URL shape goes through /shares only, which needs no Sites.Read.All.
+  describe('no /sites/* resolution path exists anymore', () => {
+    const addressBarUrl =
+      'https://tenant-my.sharepoint.com/shared?id=%2Fsites%2FDocgen%2FShared%20Documents%2Fshared&listurl=https%3A%2F%2Ftenant.sharepoint.com%2Fsites%2FDocgen%2FShared%20Documents';
+
+    test('an address-bar-style URL (with an id= query param) resolves via /shares, never /sites/', async () => {
       mockedAxios.get.mockResolvedValueOnce({ data: { id: 'item1' } });
+
+      const service = new GraphSharePointService();
+      const result = await service.testShareAccess(addressBarUrl, token);
+
+      expect(result.success).toBe(true);
+      const calledUrl = mockedAxios.get.mock.calls[0][0];
+      expect(calledUrl).toContain('/shares/');
+      expect(calledUrl).not.toContain('/sites/');
+    });
+
+    test('GraphSharePointService has no resolveFolderByPath/parseAllItemsFolderPath methods left', () => {
+      const service: any = new GraphSharePointService();
+      expect(service.resolveFolderByPath).toBeUndefined();
+      expect(service.parseAllItemsFolderPath).toBeUndefined();
+    });
+  });
+
+  describe('resolveShareRoot', () => {
+    test('returns driveId/itemId/name from the resolved driveItem', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { id: 'item-1', name: 'DocGen Templates', parentReference: { driveId: 'drive-1' } },
+      });
+
+      const service = new GraphSharePointService();
+      const result = await service.resolveShareRoot(shareUrl, token);
+
+      expect(result).toEqual({ driveId: 'drive-1', itemId: 'item-1', name: 'DocGen Templates' });
+      const calledUrl = mockedAxios.get.mock.calls[0][0];
+      expect(calledUrl).toMatch(/\/shares\/u![^/]+\/driveItem$/);
+    });
+
+    test('throws a clear error when the response has no driveId/itemId', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { name: 'incomplete' } });
+
+      const service = new GraphSharePointService();
+
+      await expect(service.resolveShareRoot(shareUrl, token)).rejects.toThrow(
+        'Could not resolve a drive/item reference from this SharePoint link'
+      );
+    });
+  });
+
+  describe('no redemption side effects (Prefer header)', () => {
+    test('testShareAccess sends no Prefer header at all — redeeming a link is a permission-granting side effect this read-only app must not cause', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { id: 'item1' } });
+      const service = new GraphSharePointService();
+
+      await service.testShareAccess(shareUrl, token);
+
+      const [, requestConfig] = mockedAxios.get.mock.calls[0];
+      expect(requestConfig.headers.Prefer).toBeUndefined();
+      expect(requestConfig.headers).toEqual({ Authorization: `Bearer ${token.accessToken}` });
+    });
+
+    test('resolveShareRoot sends no Prefer header', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { id: 'item1', parentReference: { driveId: 'd1' } } });
+      const service = new GraphSharePointService();
+
+      await service.resolveShareRoot(shareUrl, token);
+
+      const [, requestConfig] = mockedAxios.get.mock.calls[0];
+      expect(requestConfig.headers.Prefer).toBeUndefined();
+    });
+
+    test('listTemplateFiles sends no Prefer header on any request in the walk', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { value: [] } });
+      const service = new GraphSharePointService();
+
+      await service.listTemplateFiles(shareUrl, token);
+
+      for (const call of mockedAxios.get.mock.calls) {
+        expect(call[1].headers.Prefer).toBeUndefined();
+      }
+    });
+  });
+
+  describe('testShareAccess', () => {
+    test('returns success when /shares/{id}/driveItem/children resolves', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { value: [] } });
 
       const service = new GraphSharePointService();
       const result = await service.testShareAccess(shareUrl, token);
@@ -207,27 +171,29 @@ describe('GraphSharePointService', () => {
         message: 'Successfully connected to SharePoint via Microsoft Graph',
       });
       expect(mockedAxios.get).toHaveBeenCalledWith(
-        expect.stringMatching(/^https:\/\/graph\.microsoft\.com\/v1\.0\/shares\/u!/),
+        expect.stringMatching(/^https:\/\/graph\.microsoft\.com\/v1\.0\/shares\/u!.*\/driveItem\/children$/),
         {
           timeout: 15000,
           headers: {
             Authorization: `Bearer ${token.accessToken}`,
-            Prefer: 'redeemSharingLinkIfNecessary',
           },
         }
       );
     });
 
-    test('sends Prefer: redeemSharingLinkIfNecessary — /shares needs this to fully resolve a link the caller has not "opened" before, even with sufficient token scope', async () => {
-      mockedAxios.get.mockResolvedValueOnce({ data: { id: 'item1' } });
+    test('accepts a GraphTokenProvider function in place of a plain token object, and calls it to get the access token', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { value: [] } });
+      const tokenProvider = jest.fn().mockResolvedValue('provider-issued-token');
+
       const service = new GraphSharePointService();
+      await service.testShareAccess(shareUrl, tokenProvider);
 
-      await service.testShareAccess(shareUrl, token);
-
-      expect(mockedAxios.get.mock.calls[0][1].headers.Prefer).toBe('redeemSharingLinkIfNecessary');
+      expect(tokenProvider).toHaveBeenCalled();
+      const [, requestConfig] = mockedAxios.get.mock.calls[0];
+      expect(requestConfig.headers.Authorization).toBe('Bearer provider-issued-token');
     });
 
-    test('maps a 401 to a token-expired message', async () => {
+    test('maps a 401 to a re-authentication message (no longer paste-specific wording)', async () => {
       mockedAxios.get.mockRejectedValueOnce({ response: { status: 401 } });
 
       const service = new GraphSharePointService();
@@ -235,6 +201,7 @@ describe('GraphSharePointService', () => {
 
       expect(result.success).toBe(false);
       expect(result.message).toContain('expired or invalid');
+      expect(result.message).not.toContain('paste');
     });
 
     test('maps a 403 to a permission message', async () => {
@@ -286,12 +253,17 @@ describe('GraphSharePointService', () => {
     });
 
     // Drives fake timers forward while withThrottleRetry is awaiting sleep().
+    // Needs a few more ticks than a bare axios call would, since get() now
+    // awaits the token provider before each request — an extra microtask
+    // hop per attempt.
     async function flushRetries() {
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < 10; i++) {
         await Promise.resolve();
         jest.runAllTimers();
       }
     }
+
+    const constantTokenProvider = async () => 'tok';
 
     test('retries a thrown 429 and succeeds on the next attempt', async () => {
       const throttled: any = new Error('Too Many Requests');
@@ -299,7 +271,7 @@ describe('GraphSharePointService', () => {
       mockedAxios.get.mockRejectedValueOnce(throttled).mockResolvedValueOnce({ data: { id: 'item1' } });
 
       const service = new GraphSharePointService();
-      const promise = (service as any).get('https://graph.microsoft.com/v1.0/x', 'tok');
+      const promise = (service as any).get('https://graph.microsoft.com/v1.0/x', constantTokenProvider);
       await flushRetries();
       const result = await promise;
 
@@ -313,8 +285,8 @@ describe('GraphSharePointService', () => {
       mockedAxios.get.mockRejectedValue(denied);
 
       const service = new GraphSharePointService();
-      await expect((service as any).get('https://graph.microsoft.com/v1.0/x', 'tok')).rejects.toThrow(
-        'This token does not have permission to read this SharePoint folder'
+      await expect((service as any).get('https://graph.microsoft.com/v1.0/x', constantTokenProvider)).rejects.toThrow(
+        'This account does not have permission to read this SharePoint folder'
       );
       expect(mockedAxios.get).toHaveBeenCalledTimes(1);
     });
@@ -325,7 +297,7 @@ describe('GraphSharePointService', () => {
       mockedAxios.get.mockRejectedValue(throttled);
 
       const service = new GraphSharePointService();
-      const promise = (service as any).get('https://graph.microsoft.com/v1.0/x', 'tok');
+      const promise = (service as any).get('https://graph.microsoft.com/v1.0/x', constantTokenProvider);
       await flushRetries();
 
       await expect(promise).rejects.toThrow('Microsoft Graph error: 503');
@@ -336,12 +308,60 @@ describe('GraphSharePointService', () => {
       mockedAxios.get.mockResolvedValueOnce({ data: {} });
 
       const service = new GraphSharePointService();
-      await (service as any).get('https://graph.microsoft.com/v1.0/x', 'tok');
+      await (service as any).get('https://graph.microsoft.com/v1.0/x', constantTokenProvider);
 
       expect(mockedAxios.get).toHaveBeenCalledWith(
         'https://graph.microsoft.com/v1.0/x',
         expect.objectContaining({ timeout: 15000 })
       );
+    });
+
+    // The whole reason createTokenProvider re-acquires on every call: a
+    // provider function is invoked once per retry attempt too, not cached
+    // by this layer — so a token that just expired mid-retry-loop can be
+    // refreshed by the caller's own provider on the next attempt.
+    test('calls the token provider again on each retry attempt, not just once', async () => {
+      const throttled: any = new Error('Too Many Requests');
+      throttled.response = { status: 429, headers: { 'retry-after': '1' } };
+      mockedAxios.get.mockRejectedValueOnce(throttled).mockResolvedValueOnce({ data: {} });
+      const tokenProvider = jest.fn().mockResolvedValue('tok');
+
+      const service = new GraphSharePointService();
+      const promise = (service as any).get('https://graph.microsoft.com/v1.0/x', tokenProvider);
+      await flushRetries();
+      await promise;
+
+      expect(tokenProvider).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('SSRF guard on @odata.nextLink', () => {
+    test('follows a legitimate graph.microsoft.com nextLink', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: { value: [], '@odata.nextLink': 'https://graph.microsoft.com/v1.0/next-page' } })
+        .mockResolvedValueOnce({ data: { value: [] } });
+
+      const service = new GraphSharePointService();
+      await service.listTemplateFiles(shareUrl, token);
+
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+      expect(mockedAxios.get).toHaveBeenNthCalledWith(2, 'https://graph.microsoft.com/v1.0/next-page', expect.anything());
+    });
+
+    test.each([
+      ['a different host entirely', 'https://evil.example.com/steal-the-token'],
+      ['a lookalike subdomain suffix', 'https://graph.microsoft.com.evil.com/x'],
+      ['plain http', 'http://graph.microsoft.com/v1.0/x'],
+      ['userinfo smuggling', 'https://graph.microsoft.com@evil.com/x'],
+    ])('refuses to follow a malicious @odata.nextLink (%s) and never fetches it', async (_label, maliciousNextLink) => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { value: [], '@odata.nextLink': maliciousNextLink } });
+
+      const service = new GraphSharePointService();
+
+      await expect(service.listTemplateFiles(shareUrl, token)).rejects.toThrow();
+      // Only the first (legitimate) call happened — the malicious nextLink
+      // was never requested.
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -659,7 +679,7 @@ describe('GraphSharePointService', () => {
       expect(files).toHaveLength(1);
       expect(files[0].docType).toBe('SVD');
       expect(skippedFolders).toEqual([
-        { relativePath: 'Denied', reason: 'This token does not have permission to read this SharePoint folder' },
+        { relativePath: 'Denied', reason: 'This account does not have permission to read this SharePoint folder' },
       ]);
     });
 
@@ -672,7 +692,7 @@ describe('GraphSharePointService', () => {
 
       const service = new GraphSharePointService();
       await expect(service.listTemplateFiles(shareUrl, token)).rejects.toThrow(
-        'Graph access token expired or invalid — paste a fresh one'
+        'Graph access token expired or invalid — please sign in again'
       );
     });
 
@@ -681,8 +701,27 @@ describe('GraphSharePointService', () => {
 
       const service = new GraphSharePointService();
       await expect(service.listTemplateFiles(shareUrl, token)).rejects.toThrow(
-        'This token does not have permission to read this SharePoint folder'
+        'This account does not have permission to read this SharePoint folder'
       );
+    });
+
+    // The core fix behind createTokenProvider: a long-running walk that
+    // spans multiple batches must re-invoke the token provider on every
+    // request, not reuse one token/credentials object captured at the
+    // start — otherwise a walk outliving a 60-90 min access token would
+    // fail partway through instead of silently refreshing.
+    test('invokes a GraphTokenProvider once per HTTP request across a multi-batch walk, not once per walk', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({
+          data: { value: [{ id: 'folder-svd', name: 'SVD', folder: {}, parentReference: { driveId: 'drive1' } }] },
+        })
+        .mockResolvedValueOnce({ data: { value: [] } });
+      const tokenProvider = jest.fn().mockResolvedValue('graph-token');
+
+      const service = new GraphSharePointService();
+      await service.listTemplateFiles(shareUrl, tokenProvider);
+
+      expect(tokenProvider).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -692,9 +731,9 @@ describe('GraphSharePointService', () => {
       mockedAxios.get.mockResolvedValueOnce({ data: payload });
 
       const service = new GraphSharePointService();
-      const result = await service.downloadFile('https://download.example/precise-url');
+      const result = await service.downloadFile('https://contoso.sharepoint.com/download/precise-url');
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('https://download.example/precise-url', {
+      expect(mockedAxios.get).toHaveBeenCalledWith('https://contoso.sharepoint.com/download/precise-url', {
         responseType: 'arraybuffer',
       });
       expect(Buffer.isBuffer(result)).toBe(true);
@@ -704,7 +743,7 @@ describe('GraphSharePointService', () => {
     test('refuses a non-https download URL', async () => {
       const service = new GraphSharePointService();
 
-      await expect(service.downloadFile('http://download.example/precise-url')).rejects.toThrow(
+      await expect(service.downloadFile('http://contoso.sharepoint.com/download/precise-url')).rejects.toThrow(
         'Refusing to fetch a non-https download URL'
       );
       expect(mockedAxios.get).not.toHaveBeenCalled();
@@ -721,5 +760,14 @@ describe('GraphSharePointService', () => {
         expect(mockedAxios.get).not.toHaveBeenCalled();
       }
     );
+
+    test('refuses a download URL from an unrecognized (non-Microsoft) host', async () => {
+      const service = new GraphSharePointService();
+
+      await expect(service.downloadFile('https://evil.example.com/precise-url')).rejects.toThrow(
+        'Refusing to fetch a download URL from an unrecognized host'
+      );
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/test/services/SharePointService.test.ts
+++ b/src/test/services/SharePointService.test.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import https from 'https';
 import {
   SharePointService,
   SharePointConfig,
@@ -46,7 +47,7 @@ describe('SharePointService', () => {
   });
 
   describe('testConnection', () => {
-    test('returns informative message for SharePoint Online without calling NTLM', async () => {
+    test('rejects username/password credentials for a SharePoint Online site without calling NTLM', async () => {
       const service = new SharePointService();
       const onlineConfig: SharePointConfig = {
         ...baseConfig,
@@ -58,8 +59,37 @@ describe('SharePointService', () => {
       const result = await service.testConnection(onlineConfig, creds);
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('SharePoint Online requires Azure AD app registration');
+      expect(result.message).toContain('requires a Microsoft Graph access token');
       expect(ntlmSpy).not.toHaveBeenCalled();
+    });
+
+    test('rejects a Graph access token for an on-premise site without calling NTLM', async () => {
+      const service = new SharePointService();
+      const ntlmSpy = (jest as any).spyOn(service as any, 'makeNTLMRequest');
+      const token: SharePointOAuthToken = { accessToken: 'abc' };
+
+      const result = await service.testConnection(baseConfig, token);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('requires a username/password');
+      expect(ntlmSpy).not.toHaveBeenCalled();
+    });
+
+    test('delegates to GraphSharePointService.testShareAccess for a SharePoint Online site with a token', async () => {
+      const service = new SharePointService();
+      const onlineConfig: SharePointConfig = {
+        ...baseConfig,
+        siteUrl: 'https://tenant.sharepoint.com/:f:/s/site/shareToken',
+      };
+      const token: SharePointOAuthToken = { accessToken: 'abc' };
+      const graphSpy = (jest as any)
+        .spyOn((service as any).graphService, 'testShareAccess')
+        .mockResolvedValueOnce({ success: true, message: 'ok via graph' });
+
+      const result = await service.testConnection(onlineConfig, token);
+
+      expect(graphSpy).toHaveBeenCalledWith(onlineConfig.siteUrl, token);
+      expect(result).toEqual({ success: true, message: 'ok via graph' });
     });
 
     test('returns success when NTLM request returns 200', async () => {
@@ -99,6 +129,35 @@ describe('SharePointService', () => {
   });
 
   describe('listTemplateFiles', () => {
+    test('throws instead of silently returning [] when subfolders response is not the expected JSON shape', async () => {
+      const service = new SharePointService();
+      (jest as any).spyOn(service as any, 'makeSharePointRequest').mockResolvedValueOnce({
+        data: '<feed xmlns="http://www.w3.org/2005/Atom">...</feed>',
+        headers: { 'content-type': 'application/atom+xml' },
+      });
+
+      await expect(service.listTemplateFiles(baseConfig, creds)).rejects.toThrow(
+        /Unexpected response fetching subfolders/
+      );
+    });
+
+    test('throws instead of silently returning [] when a subfolder files response is not the expected JSON shape', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({
+          data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
+        })
+        .mockResolvedValueOnce({
+          data: '<feed xmlns="http://www.w3.org/2005/Atom">...</feed>',
+          headers: { 'content-type': 'application/atom+xml' },
+        });
+
+      await expect(service.listTemplateFiles(baseConfig, creds)).rejects.toThrow(
+        /Unexpected response fetching files in subfolder "SVD"/
+      );
+    });
+
     test('aggregates .docx/.dotx files per subfolder as docType', async () => {
       const service = new SharePointService();
       const makeReqSpy = (jest as any)
@@ -122,6 +181,7 @@ describe('SharePointService', () => {
                 {
                   Name: 'SVD-template.docx',
                   ServerRelativeUrl: '/sites/project/Templates/SVD/SVD-template.docx',
+                  TimeCreated: '2023-12-01T00:00:00Z',
                   TimeLastModified: '2024-01-01T00:00:00Z',
                   Length: 1234,
                 },
@@ -143,11 +203,69 @@ describe('SharePointService', () => {
         {
           name: 'SVD-template.docx',
           serverRelativeUrl: '/sites/project/Templates/SVD/SVD-template.docx',
+          timeCreated: '2023-12-01T00:00:00Z',
           timeLastModified: '2024-01-01T00:00:00Z',
           length: 1234,
           docType: 'SVD',
         },
       ]);
+    });
+
+    test('excludes Office lock/temp files (~$...) even though they end in .docx/.dotx', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({
+          data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            d: {
+              results: [
+                // Matches the real seed asset in this repo:
+                // s3-initializer/assets/templates/shared/SVD/~$ftware Version Description.dotx
+                {
+                  Name: '~$ftware Version Description.dotx',
+                  ServerRelativeUrl: '/sites/project/Templates/SVD/~$ftware Version Description.dotx',
+                  TimeLastModified: '2024-01-01T00:00:00Z',
+                  Length: 162,
+                },
+              ],
+            },
+          },
+        });
+
+      const files = await service.listTemplateFiles(baseConfig, creds);
+
+      expect(files).toEqual([]);
+    });
+
+    test('excludes a file over the max template size and logs why', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({
+          data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            d: {
+              results: [
+                {
+                  Name: 'huge-template.docx',
+                  ServerRelativeUrl: '/sites/project/Templates/SVD/huge-template.docx',
+                  TimeLastModified: '2024-01-01T00:00:00Z',
+                  Length: 51 * 1024 * 1024,
+                },
+              ],
+            },
+          },
+        });
+
+      const files = await service.listTemplateFiles(baseConfig, creds);
+
+      expect(files).toEqual([]);
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('exceeds the sync limit'));
     });
 
     test('throws descriptive error when makeSharePointRequest fails', async () => {
@@ -163,12 +281,43 @@ describe('SharePointService', () => {
         expect.stringContaining('Failed to list SharePoint files: list failed')
       );
     });
+
+    test('delegates to GraphSharePointService for a SharePoint Online site with a token, bypassing the REST/NTLM path', async () => {
+      const service = new SharePointService();
+      const onlineConfig: SharePointConfig = {
+        ...baseConfig,
+        siteUrl: 'https://tenant.sharepoint.com/:f:/s/site/shareToken',
+      };
+      const token: SharePointOAuthToken = { accessToken: 'abc' };
+      const graphFiles = [
+        {
+          name: 'SVD-template.docx',
+          serverRelativeUrl: 'https://graph-download.example/precise-url',
+          timeLastModified: '2024-01-01T00:00:00Z',
+          length: 1234,
+          docType: 'SVD',
+        },
+      ];
+      const graphSpy = (jest as any)
+        .spyOn((service as any).graphService, 'listTemplateFiles')
+        .mockResolvedValueOnce(graphFiles);
+      const restSpy = (jest as any).spyOn(service as any, 'makeSharePointRequest');
+
+      const files = await service.listTemplateFiles(onlineConfig, token);
+
+      expect(graphSpy).toHaveBeenCalledWith(onlineConfig.siteUrl, token);
+      expect(restSpy).not.toHaveBeenCalled();
+      expect(files).toEqual(graphFiles);
+    });
   });
 
   describe('downloadFile', () => {
     test('returns buffer from makeSharePointRequest data', async () => {
       const service = new SharePointService();
-      const payload = Buffer.from('hello');
+      // Real .docx/.dotx files are ZIP archives — downloadFile now rejects
+      // anything that doesn't start with the ZIP signature, so the fixture
+      // must include it to exercise the "valid file" path.
+      const payload = Buffer.concat([Buffer.from([0x50, 0x4b, 0x03, 0x04]), Buffer.from('hello')]);
       const spy = (jest as any)
         .spyOn(service as any, 'makeSharePointRequest')
         .mockResolvedValueOnce({ data: payload });
@@ -186,7 +335,18 @@ describe('SharePointService', () => {
         { responseType: 'arraybuffer' }
       );
       expect(Buffer.isBuffer(result)).toBe(true);
-      expect(result.toString()).toBe('hello');
+      expect(result.equals(payload)).toBe(true);
+    });
+
+    test('rejects a downloaded file that is not a valid ZIP/OOXML package', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({ data: Buffer.from('not a real docx') });
+
+      await expect(
+        service.downloadFile(baseConfig.siteUrl, '/sites/project/Templates/SVD/fake.docx', creds)
+      ).rejects.toThrow('not a valid Office document — failed content check');
     });
 
     test('throws descriptive error when makeSharePointRequest fails', async () => {
@@ -201,6 +361,175 @@ describe('SharePointService', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed to download file /some/file.docx: download failed')
       );
+    });
+
+    test('delegates to GraphSharePointService for a SharePoint Online site with a token, bypassing the REST/NTLM path', async () => {
+      const service = new SharePointService();
+      const token: SharePointOAuthToken = { accessToken: 'abc' };
+      const graphBuffer = Buffer.concat([Buffer.from([0x50, 0x4b, 0x03, 0x04]), Buffer.from('graph-file-bytes')]);
+      const graphSpy = (jest as any)
+        .spyOn((service as any).graphService, 'downloadFile')
+        .mockResolvedValueOnce(graphBuffer);
+      const restSpy = (jest as any).spyOn(service as any, 'makeSharePointRequest');
+
+      const result = await service.downloadFile(
+        'https://tenant.sharepoint.com/:f:/s/site/shareToken',
+        'https://graph-download.example/precise-url',
+        token
+      );
+
+      expect(graphSpy).toHaveBeenCalledWith('https://graph-download.example/precise-url');
+      expect(restSpy).not.toHaveBeenCalled();
+      expect(result).toBe(graphBuffer);
+    });
+  });
+
+  describe('resolveSiteFromUrl', () => {
+    test('resolves siteUrl/folder from a pasted deep folder URL, stripping the site prefix out of folder', async () => {
+      const service = new SharePointService();
+      const ntlmSpy = (jest as any)
+        .spyOn(service as any, 'makeNTLMRequest')
+        .mockResolvedValueOnce({ data: { d: { ServerRelativeUrl: '/sites/project' } } });
+
+      const result = await service.resolveSiteFromUrl(
+        'http://sp-server/sites/project/Shared Documents/02 Engineering/Templates',
+        creds
+      );
+
+      expect(ntlmSpy).toHaveBeenCalledWith(
+        'http://sp-server/sites/project/Shared Documents/02 Engineering/Templates/_api/web?$select=ServerRelativeUrl',
+        creds,
+        'GET'
+      );
+      expect(result).toEqual({
+        siteUrl: 'http://sp-server/sites/project',
+        library: '',
+        folder: 'Shared Documents/02 Engineering/Templates',
+      });
+    });
+
+    test('strips a trailing slash from the pasted URL before appending _api/web', async () => {
+      const service = new SharePointService();
+      const ntlmSpy = (jest as any)
+        .spyOn(service as any, 'makeNTLMRequest')
+        .mockResolvedValueOnce({ data: { d: { ServerRelativeUrl: '/sites/project' } } });
+
+      await service.resolveSiteFromUrl('http://sp-server/sites/project/Templates/', creds);
+
+      expect(ntlmSpy).toHaveBeenCalledWith(
+        'http://sp-server/sites/project/Templates/_api/web?$select=ServerRelativeUrl',
+        creds,
+        'GET'
+      );
+    });
+
+    test('strips the query string before appending _api/web, for a pasted AllItems.aspx URL', async () => {
+      const service = new SharePointService();
+      const ntlmSpy = (jest as any)
+        .spyOn(service as any, 'makeNTLMRequest')
+        .mockResolvedValueOnce({ data: { d: { ServerRelativeUrl: '/DevOPs' } } });
+
+      await service.resolveSiteFromUrl(
+        'http://elissp/DevOPs/Shared Documents/Forms/AllItems.aspx?web=1&RootFolder=%2fDevOPs%2fShared%20Documents%2fTraining%20and%20Templates%2fDocGen%20Templates&FolderCTID=0x012000B3FA09F870FEDE4A8F7582FA6AB1AE75',
+        creds
+      );
+
+      expect(ntlmSpy).toHaveBeenCalledWith(
+        'http://elissp/DevOPs/Shared Documents/Forms/AllItems.aspx/_api/web?$select=ServerRelativeUrl',
+        creds,
+        'GET'
+      );
+    });
+
+    test('prefers the RootFolder= query param over the page path for the resolved folder — on-prem\'s equivalent of Online\'s ?id= shape', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeNTLMRequest')
+        .mockResolvedValueOnce({ data: { d: { ServerRelativeUrl: '/DevOPs' } } });
+
+      const result = await service.resolveSiteFromUrl(
+        'http://elissp/DevOPs/Shared Documents/Forms/AllItems.aspx?web=1&RootFolder=%2fDevOPs%2fShared%20Documents%2fTraining%20and%20Templates%2fDocGen%20Templates&FolderCTID=0x012000B3FA09F870FEDE4A8F7582FA6AB1AE75',
+        creds
+      );
+
+      // Must resolve to the real target folder (from RootFolder=), NOT
+      // "Shared Documents/Forms/AllItems.aspx" (the page's own path).
+      expect(result).toEqual({
+        siteUrl: 'http://elissp/DevOPs',
+        library: '',
+        folder: 'Shared Documents/Training and Templates/DocGen Templates',
+      });
+    });
+
+    test('resolved folder is usable by constructFolderPath without a doubled/duplicated site path', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeNTLMRequest')
+        .mockResolvedValueOnce({ data: { d: { ServerRelativeUrl: '/sites/project' } } });
+
+      const resolved = await service.resolveSiteFromUrl(
+        'http://sp-server/sites/project/Shared Documents/Templates',
+        creds
+      );
+
+      const rebuilt = (service as any).constructFolderPath({
+        siteUrl: resolved.siteUrl,
+        library: resolved.library,
+        folder: resolved.folder,
+      });
+
+      expect(rebuilt).toBe('/sites/project/Shared Documents/Templates');
+    });
+
+    test('throws a descriptive error when the response has no ServerRelativeUrl', async () => {
+      const service = new SharePointService();
+      (jest as any).spyOn(service as any, 'makeNTLMRequest').mockResolvedValueOnce({
+        data: '<feed xmlns="http://www.w3.org/2005/Atom">...</feed>',
+        headers: { 'content-type': 'application/atom+xml' },
+      });
+
+      await expect(
+        service.resolveSiteFromUrl('http://sp-server/sites/project/Templates', creds)
+      ).rejects.toThrow(/Could not resolve a SharePoint site from this URL/);
+    });
+
+    test('propagates a rejected request as a descriptive error', async () => {
+      const service = new SharePointService();
+      (jest as any).spyOn(service as any, 'makeNTLMRequest').mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+      await expect(
+        service.resolveSiteFromUrl('http://sp-server/sites/project/Templates', creds)
+      ).rejects.toThrow('Failed to resolve SharePoint site from URL: ECONNREFUSED');
+    });
+
+    test('does not double-decode RootFolder= — a folder name containing a literal % character resolves correctly', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeNTLMRequest')
+        .mockResolvedValueOnce({ data: { d: { ServerRelativeUrl: '/DevOPs' } } });
+
+      const result = await service.resolveSiteFromUrl(
+        'http://elissp/DevOPs/Shared Documents/Forms/AllItems.aspx?RootFolder=%2fDevOPs%2f100%2525%20Done',
+        creds
+      );
+
+      // The raw query value %2fDevOPs%2f100%2525%20Done is percent-decoded
+      // ONCE by URLSearchParams.get() (which resolveSiteFromUrl must use
+      // as-is, not decode again): %2f -> "/", %25 -> "%", the following
+      // literal "25" stays as-is, and %20 -> " ". That yields
+      // "/DevOPs/100%25 Done" — a folder literally named "100%25 Done".
+      // A second decodeURIComponent() call (the bug) would re-decode the
+      // "%25" substring into a bare "%", silently corrupting the result to
+      // "100% Done" instead of throwing here — still wrong, just not a
+      // thrown error for this particular input (a folder name with an
+      // unencoded literal % immediately followed by a non-hex character,
+      // e.g. "100% Done", throws "URI malformed" instead — see the
+      // 'prefers the RootFolder=' test above for the non-doubled case).
+      expect(result).toEqual({
+        siteUrl: 'http://elissp/DevOPs',
+        library: '',
+        folder: '100%25 Done',
+      });
     });
   });
 
@@ -232,6 +561,37 @@ describe('SharePointService', () => {
       expect(makeNtlmSpy).toHaveBeenCalledTimes(1);
       expect(makeOAuthSpy).not.toHaveBeenCalled();
       expect(result.status).toBe(200);
+    });
+  });
+
+  describe('toServerRelativeUrlLiteral', () => {
+    test('percent-encodes spaces within a segment but leaves "/" as a literal separator', () => {
+      const service = new SharePointService();
+      const result = (service as any).toServerRelativeUrlLiteral(
+        '/sites/project/Shared Documents/02 Engineering/Templates'
+      );
+
+      // '/' must never be percent-encoded (would produce %2F, which IIS's
+      // request filtering rejects by default with 404.11 "URL Double Escaped")
+      expect(result).not.toContain('%2F');
+      expect(result).not.toContain('%2f');
+      expect(result).toBe('/sites/project/Shared%20Documents/02%20Engineering/Templates');
+    });
+
+    test('escapes a literal single quote by doubling it (OData string literal syntax)', () => {
+      const service = new SharePointService();
+      const result = (service as any).toServerRelativeUrlLiteral("/sites/project/Client's Templates");
+
+      // The doubled quote is the literal OData escape and must survive
+      // percent-encoding unencoded (encodeURIComponent does not touch ').
+      expect(result).toBe("/sites/project/Client''s%20Templates");
+    });
+
+    test('handles a path with neither spaces nor quotes unchanged (aside from the leading slash)', () => {
+      const service = new SharePointService();
+      const result = (service as any).toServerRelativeUrlLiteral('/sites/project/SVD');
+
+      expect(result).toBe('/sites/project/SVD');
     });
   });
 
@@ -269,6 +629,38 @@ describe('SharePointService', () => {
         })
       );
       expect(result).toEqual({ status: 201, data: { ok: true }, headers: { 'x-header': 'v' } });
+    });
+
+    test('makeOAuthRequest sets an httpsAgent with rejectUnauthorized:false only when SHAREPOINT_ALLOW_SELF_SIGNED=true', async () => {
+      jest.resetModules();
+      process.env.SHAREPOINT_ALLOW_SELF_SIGNED = 'true';
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { SharePointService: ReloadedService } = require('../../services/SharePointService');
+        const reloadedAxios = require('axios') as jest.MockedFunction<any>;
+        reloadedAxios.mockResolvedValueOnce({ status: 200, data: {}, headers: {} });
+
+        const service = new ReloadedService();
+        const token: SharePointOAuthToken = { accessToken: 'abc' };
+        await (service as any).makeOAuthRequest('http://url', token, 'GET', {});
+
+        const sentConfig = reloadedAxios.mock.calls[0][0];
+        expect(sentConfig.httpsAgent).toBeInstanceOf(https.Agent);
+        expect(sentConfig.httpsAgent.options.rejectUnauthorized).toBe(false);
+      } finally {
+        delete process.env.SHAREPOINT_ALLOW_SELF_SIGNED;
+        jest.resetModules();
+      }
+    });
+
+    test('makeOAuthRequest omits httpsAgent by default', async () => {
+      const service = new SharePointService();
+      mockedAxios.mockResolvedValueOnce({ status: 200, data: {}, headers: {} } as any);
+
+      const token: SharePointOAuthToken = { accessToken: 'abc' };
+      await (service as any).makeOAuthRequest('http://url', token, 'GET', {});
+
+      expect(mockedAxios.mock.calls[0][0]).not.toHaveProperty('httpsAgent');
     });
 
     test('makeOAuthRequest logs and rethrows on error', async () => {
@@ -321,6 +713,133 @@ describe('SharePointService', () => {
         data: { a: 1 },
         headers: { 'content-type': 'application/json' },
       });
+    });
+
+    test('makeNTLMRequest always sends an Accept: application/json header (on-prem SharePoint defaults to Atom XML otherwise)', async () => {
+      const service = new SharePointService();
+      const httpntlm = require('httpntlm');
+      const getMock = httpntlm.get as jest.Mock;
+
+      getMock.mockImplementationOnce((_opts: any, cb: Function) => {
+        cb(null, { statusCode: 200, headers: {}, body: '{}' });
+      });
+
+      await (service as any).makeNTLMRequest('http://sp', creds, 'GET', {});
+
+      expect(getMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({ Accept: 'application/json;odata=verbose' }),
+        }),
+        expect.any(Function)
+      );
+    });
+
+    test('makeNTLMRequest merges caller-supplied headers with the default Accept header', async () => {
+      const service = new SharePointService();
+      const httpntlm = require('httpntlm');
+      const getMock = httpntlm.get as jest.Mock;
+
+      getMock.mockImplementationOnce((_opts: any, cb: Function) => {
+        cb(null, { statusCode: 200, headers: {}, body: '{}' });
+      });
+
+      await (service as any).makeNTLMRequest('http://sp', creds, 'GET', { headers: { 'X-Test': '1' } });
+
+      expect(getMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({ Accept: 'application/json;odata=verbose', 'X-Test': '1' }),
+        }),
+        expect.any(Function)
+      );
+    });
+
+    test('makeNTLMRequest translates responseType:"arraybuffer" into binary:true so downloaded files are not utf8-stringified', async () => {
+      const service = new SharePointService();
+      const httpntlm = require('httpntlm');
+      const getMock = httpntlm.get as jest.Mock;
+
+      getMock.mockImplementationOnce((_opts: any, cb: Function) => {
+        cb(null, { statusCode: 200, headers: {}, body: Buffer.from('binary-data') });
+      });
+
+      await (service as any).makeNTLMRequest('http://sp', creds, 'GET', { responseType: 'arraybuffer' });
+
+      expect(getMock).toHaveBeenCalledWith(
+        expect.objectContaining({ binary: true }),
+        expect.any(Function)
+      );
+      // responseType itself is an axios-only key and must not leak into the httpntlm options
+      expect(getMock.mock.calls[0][0]).not.toHaveProperty('responseType');
+    });
+
+    test('makeNTLMRequest does not set binary when no arraybuffer responseType was requested', async () => {
+      const service = new SharePointService();
+      const httpntlm = require('httpntlm');
+      const getMock = httpntlm.get as jest.Mock;
+
+      getMock.mockImplementationOnce((_opts: any, cb: Function) => {
+        cb(null, { statusCode: 200, headers: {}, body: '{}' });
+      });
+
+      await (service as any).makeNTLMRequest('http://sp', creds, 'GET', {});
+
+      expect(getMock.mock.calls[0][0]).not.toHaveProperty('binary');
+    });
+
+    test('makeNTLMRequest never forwards a caller-supplied agent (would break NTLM connection affinity)', async () => {
+      const service = new SharePointService();
+      const httpntlm = require('httpntlm');
+      const getMock = httpntlm.get as jest.Mock;
+
+      getMock.mockImplementationOnce((_opts: any, cb: Function) => {
+        cb(null, { statusCode: 200, headers: {}, body: '{}' });
+      });
+
+      const bogusAgent = {};
+      await (service as any).makeNTLMRequest('http://sp', creds, 'GET', { agent: bogusAgent });
+
+      expect(getMock.mock.calls[0][0].agent).not.toBe(bogusAgent);
+      expect(getMock.mock.calls[0][0]).not.toHaveProperty('agent');
+    });
+
+    test('makeNTLMRequest sets rejectUnauthorized:false only when SHAREPOINT_ALLOW_SELF_SIGNED=true', async () => {
+      jest.resetModules();
+      process.env.SHAREPOINT_ALLOW_SELF_SIGNED = 'true';
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { SharePointService: ReloadedService } = require('../../services/SharePointService');
+        const httpntlm = require('httpntlm');
+        const getMock = httpntlm.get as jest.Mock;
+
+        getMock.mockImplementationOnce((_opts: any, cb: Function) => {
+          cb(null, { statusCode: 200, headers: {}, body: '{}' });
+        });
+
+        const service = new ReloadedService();
+        await (service as any).makeNTLMRequest('http://sp', creds, 'GET', {});
+
+        expect(getMock).toHaveBeenCalledWith(
+          expect.objectContaining({ rejectUnauthorized: false }),
+          expect.any(Function)
+        );
+      } finally {
+        delete process.env.SHAREPOINT_ALLOW_SELF_SIGNED;
+        jest.resetModules();
+      }
+    });
+
+    test('makeNTLMRequest omits rejectUnauthorized by default', async () => {
+      const service = new SharePointService();
+      const httpntlm = require('httpntlm');
+      const getMock = httpntlm.get as jest.Mock;
+
+      getMock.mockImplementationOnce((_opts: any, cb: Function) => {
+        cb(null, { statusCode: 200, headers: {}, body: '{}' });
+      });
+
+      await (service as any).makeNTLMRequest('http://sp', creds, 'GET', {});
+
+      expect(getMock.mock.calls[0][0]).not.toHaveProperty('rejectUnauthorized');
     });
 
     test('makeNTLMRequest rejects when httpntlm returns error', async () => {

--- a/src/test/services/SharePointService.test.ts
+++ b/src/test/services/SharePointService.test.ts
@@ -158,6 +158,29 @@ describe('SharePointService', () => {
       );
     });
 
+    // Regression: a pasted templates folder that doesn't exist on the
+    // SharePoint server returns SharePoint's own REST error body (a 404
+    // with an OData error object), not a list. That specific, human-
+    // readable message ("File Not Found.") must reach the user instead of
+    // the generic "Unexpected response... Body preview: {...}" dump.
+    test('surfaces SharePoint\'s own error message when the templates folder does not exist', async () => {
+      const service = new SharePointService();
+      (jest as any).spyOn(service as any, 'makeSharePointRequest').mockResolvedValueOnce({
+        status: 404,
+        data: {
+          error: {
+            code: '-2130575338, Microsoft.SharePoint.SPException',
+            message: { lang: 'en-US', value: 'File Not Found.' },
+          },
+        },
+        headers: { 'content-type': 'application/json;odata=verbose' },
+      });
+
+      await expect(service.listTemplateFiles(baseConfig, creds)).rejects.toThrow(
+        /SharePoint returned an error while fetching subfolders: File Not Found\./
+      );
+    });
+
     test('aggregates .docx/.dotx files per subfolder as docType', async () => {
       const service = new SharePointService();
       const makeReqSpy = (jest as any)

--- a/src/test/services/SharePointService.test.ts
+++ b/src/test/services/SharePointService.test.ts
@@ -92,6 +92,26 @@ describe('SharePointService', () => {
       expect(result).toEqual({ success: true, message: 'ok via graph' });
     });
 
+    // The BFF session flow passes a GraphTokenProvider closure instead of a
+    // plain { accessToken } object — isTokenBased() must recognize both
+    // shapes as OAuth/Graph-bound, not just the legacy object shape.
+    test('also delegates to GraphSharePointService when given a GraphTokenProvider function instead of a plain token object', async () => {
+      const service = new SharePointService();
+      const onlineConfig: SharePointConfig = {
+        ...baseConfig,
+        siteUrl: 'https://tenant.sharepoint.com/:f:/s/site/shareToken',
+      };
+      const tokenProvider = async () => 'provider-issued-token';
+      const graphSpy = (jest as any)
+        .spyOn((service as any).graphService, 'testShareAccess')
+        .mockResolvedValueOnce({ success: true, message: 'ok via graph' });
+
+      const result = await service.testConnection(onlineConfig, tokenProvider);
+
+      expect(graphSpy).toHaveBeenCalledWith(onlineConfig.siteUrl, tokenProvider);
+      expect(result).toEqual({ success: true, message: 'ok via graph' });
+    });
+
     test('returns success when NTLM request returns 200', async () => {
       const service = new SharePointService();
       const ntlmSpy = (jest as any)

--- a/src/test/services/SharePointService.test.ts
+++ b/src/test/services/SharePointService.test.ts
@@ -129,15 +129,20 @@ describe('SharePointService', () => {
   });
 
   describe('listTemplateFiles', () => {
+    // The recursive walk fetches Files then Folders at each level, root
+    // first — so the first mocked call is always the root folder's Files.
     test('throws instead of silently returning [] when subfolders response is not the expected JSON shape', async () => {
       const service = new SharePointService();
-      (jest as any).spyOn(service as any, 'makeSharePointRequest').mockResolvedValueOnce({
-        data: '<feed xmlns="http://www.w3.org/2005/Atom">...</feed>',
-        headers: { 'content-type': 'application/atom+xml' },
-      });
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }) // Files(root)
+        .mockResolvedValueOnce({
+          data: '<feed xmlns="http://www.w3.org/2005/Atom">...</feed>',
+          headers: { 'content-type': 'application/atom+xml' },
+        }); // Folders(root) — bad shape
 
       await expect(service.listTemplateFiles(baseConfig, creds)).rejects.toThrow(
-        /Unexpected response fetching subfolders/
+        /Unexpected response fetching subfolders in/
       );
     });
 
@@ -145,16 +150,17 @@ describe('SharePointService', () => {
       const service = new SharePointService();
       (jest as any)
         .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }) // Files(root)
         .mockResolvedValueOnce({
           data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
-        })
+        }) // Folders(root)
         .mockResolvedValueOnce({
           data: '<feed xmlns="http://www.w3.org/2005/Atom">...</feed>',
           headers: { 'content-type': 'application/atom+xml' },
-        });
+        }); // Files(SVD) — bad shape
 
       await expect(service.listTemplateFiles(baseConfig, creds)).rejects.toThrow(
-        /Unexpected response fetching files in subfolder "SVD"/
+        /Unexpected response fetching files in/
       );
     });
 
@@ -177,15 +183,17 @@ describe('SharePointService', () => {
       });
 
       await expect(service.listTemplateFiles(baseConfig, creds)).rejects.toThrow(
-        /SharePoint returned an error while fetching subfolders: File Not Found\./
+        /SharePoint returned an error while fetching files in ".*": File Not Found\./
       );
     });
 
-    test('aggregates .docx/.dotx files per subfolder as docType', async () => {
+    test('aggregates .docx/.dotx files per subfolder as docType, tagged with a relativePath', async () => {
       const service = new SharePointService();
       const makeReqSpy = (jest as any)
         .spyOn(service as any, 'makeSharePointRequest')
-        // First call: subfolders list
+        // 1: Files at root — none directly at the connected root
+        .mockResolvedValueOnce({ data: { d: { results: [] } } })
+        // 2: Folders at root
         .mockResolvedValueOnce({
           data: {
             d: {
@@ -196,7 +204,7 @@ describe('SharePointService', () => {
             },
           },
         })
-        // Second call: files in SVD subfolder
+        // 3: Files in SVD subfolder
         .mockResolvedValueOnce({
           data: {
             d: {
@@ -217,11 +225,16 @@ describe('SharePointService', () => {
               ],
             },
           },
-        });
+        })
+        // 4: Folders in SVD subfolder — no further nesting
+        .mockResolvedValueOnce({ data: { d: { results: [] } } });
 
-      const files = await service.listTemplateFiles(baseConfig, creds);
+      const { files, truncated } = await service.listTemplateFiles(baseConfig, creds);
 
-      expect(makeReqSpy).toHaveBeenCalledTimes(2);
+      // Files(root), Folders(root), Files(SVD), Folders(SVD). _hidden must
+      // never be queued — no calls issued for it.
+      expect(makeReqSpy).toHaveBeenCalledTimes(4);
+      expect(truncated).toBe(false);
       expect(files).toEqual([
         {
           name: 'SVD-template.docx',
@@ -230,6 +243,116 @@ describe('SharePointService', () => {
           timeLastModified: '2024-01-01T00:00:00Z',
           length: 1234,
           docType: 'SVD',
+          relativePath: 'SVD/SVD-template.docx',
+        },
+      ]);
+    });
+
+    // A3: the BFS walk now fetches CONCURRENT_FOLDER_FETCHES folders at a
+    // time instead of one at a time. This must not change the output —
+    // uses mockImplementation keyed on the actual URL requested (not a
+    // fixed mockResolvedValueOnce queue) so the assertions hold regardless
+    // of which order the concurrent fetches actually settle in.
+    test('processes a wide batch of subfolders concurrently with deterministic, correctly-associated output', async () => {
+      const service = new SharePointService();
+      const subfolderNames = ['F0', 'F1', 'F2', 'F3', 'F4', 'F5']; // 6 — spans 2 batches at CONCURRENT_FOLDER_FETCHES=4
+
+      (jest as any).spyOn(service as any, 'makeSharePointRequest').mockImplementation(async (url: string) => {
+        const rootFilesUrl =
+          "http://sp-server/sites/project/_api/web/GetFolderByServerRelativeUrl('/sites/project/Templates/DocGen')/Files";
+        const rootFoldersUrl =
+          "http://sp-server/sites/project/_api/web/GetFolderByServerRelativeUrl('/sites/project/Templates/DocGen')/Folders";
+
+        if (url === rootFilesUrl) return { data: { d: { results: [] } } };
+        if (url === rootFoldersUrl) {
+          return {
+            data: {
+              d: {
+                results: subfolderNames.map((name) => ({
+                  Name: name,
+                  ServerRelativeUrl: `/sites/project/Templates/DocGen/${name}`,
+                })),
+              },
+            },
+          };
+        }
+
+        for (const name of subfolderNames) {
+          const filesUrl = `http://sp-server/sites/project/_api/web/GetFolderByServerRelativeUrl('/sites/project/Templates/DocGen/${name}')/Files`;
+          const foldersUrl = `http://sp-server/sites/project/_api/web/GetFolderByServerRelativeUrl('/sites/project/Templates/DocGen/${name}')/Folders`;
+          if (url === filesUrl) {
+            return {
+              data: {
+                d: {
+                  results: [
+                    {
+                      Name: `${name}-template.docx`,
+                      ServerRelativeUrl: `/sites/project/Templates/DocGen/${name}/${name}-template.docx`,
+                      TimeLastModified: '2024-01-01T00:00:00Z',
+                      Length: 10,
+                    },
+                  ],
+                },
+              },
+            };
+          }
+          if (url === foldersUrl) return { data: { d: { results: [] } } };
+        }
+
+        throw new Error(`Unexpected URL in test: ${url}`);
+      });
+
+      const { files, truncated } = await service.listTemplateFiles(baseConfig, creds);
+
+      expect(truncated).toBe(false);
+      expect(files).toHaveLength(6);
+      // Deterministic: output must follow original queue (BFS) order, not
+      // whatever order the concurrent batch happened to settle in.
+      expect(files.map((f) => f.relativePath)).toEqual([
+        'F0/F0-template.docx',
+        'F1/F1-template.docx',
+        'F2/F2-template.docx',
+        'F3/F3-template.docx',
+        'F4/F4-template.docx',
+        'F5/F5-template.docx',
+      ]);
+      files.forEach((f, i) => expect(f.docType).toBe(subfolderNames[i]));
+    });
+
+    test('lists a file sitting directly at the connected root with no docType (flat-folder case)', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        // 1: Files at root — a flat folder's files live here directly
+        .mockResolvedValueOnce({
+          data: {
+            d: {
+              results: [
+                {
+                  Name: 'Some-Template.dotx',
+                  ServerRelativeUrl: '/sites/project/Templates/DocGen/Some-Template.dotx',
+                  TimeLastModified: '2024-01-01T00:00:00Z',
+                  Length: 500,
+                },
+              ],
+            },
+          },
+        })
+        // 2: Folders at root — none
+        .mockResolvedValueOnce({ data: { d: { results: [] } } });
+
+      const { files, truncated } = await service.listTemplateFiles(baseConfig, creds);
+
+      expect(truncated).toBe(false);
+      expect(files).toEqual([
+        {
+          name: 'Some-Template.dotx',
+          serverRelativeUrl: '/sites/project/Templates/DocGen/Some-Template.dotx',
+          timeCreated: undefined,
+          timeLastModified: '2024-01-01T00:00:00Z',
+          length: 500,
+          docType: undefined,
+          relativePath: 'Some-Template.dotx',
         },
       ]);
     });
@@ -238,9 +361,10 @@ describe('SharePointService', () => {
       const service = new SharePointService();
       (jest as any)
         .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }) // Files(root)
         .mockResolvedValueOnce({
           data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
-        })
+        }) // Folders(root)
         .mockResolvedValueOnce({
           data: {
             d: {
@@ -256,9 +380,10 @@ describe('SharePointService', () => {
               ],
             },
           },
-        });
+        }) // Files(SVD)
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }); // Folders(SVD)
 
-      const files = await service.listTemplateFiles(baseConfig, creds);
+      const { files } = await service.listTemplateFiles(baseConfig, creds);
 
       expect(files).toEqual([]);
     });
@@ -267,9 +392,10 @@ describe('SharePointService', () => {
       const service = new SharePointService();
       (jest as any)
         .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }) // Files(root)
         .mockResolvedValueOnce({
           data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
-        })
+        }) // Folders(root)
         .mockResolvedValueOnce({
           data: {
             d: {
@@ -283,12 +409,192 @@ describe('SharePointService', () => {
               ],
             },
           },
-        });
+        }) // Files(SVD)
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }); // Folders(SVD)
 
-      const files = await service.listTemplateFiles(baseConfig, creds);
+      const { files } = await service.listTemplateFiles(baseConfig, creds);
 
       expect(files).toEqual([]);
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('exceeds the sync limit'));
+    });
+
+    test('truncates and flags it when the file count cap is hit', async () => {
+      const service = new SharePointService();
+      // One over the cap — the 501st push is what actually flips
+      // `truncated`. Since fetchFolder always fetches /Folders too (the
+      // running total across a concurrent batch isn't known per-item, so
+      // the old per-item short-circuit isn't available), Folders(root)
+      // still needs a mock even though its result is discarded once
+      // truncation is detected while accumulating this folder's files.
+      const manyFiles = Array.from({ length: 501 }, (_, i) => ({
+        Name: `T${i}.docx`,
+        ServerRelativeUrl: `/sites/project/Templates/DocGen/T${i}.docx`,
+        TimeLastModified: '2024-01-01T00:00:00Z',
+        Length: 10,
+      }));
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        // Files(root) — over the 500-file cap in one response
+        .mockResolvedValueOnce({ data: { d: { results: manyFiles } } })
+        // Folders(root) — fetched regardless, result discarded
+        .mockResolvedValueOnce({ data: { d: { results: [] } } });
+
+      const { files, truncated } = await service.listTemplateFiles(baseConfig, creds);
+
+      expect(truncated).toBe(true);
+      expect(files).toHaveLength(500);
+    });
+
+    test('skips a permission-denied subfolder (resolved 403) and keeps files already found', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }) // Files(root)
+        .mockResolvedValueOnce({
+          data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
+        }) // Folders(root)
+        .mockResolvedValueOnce({
+          status: 403,
+          data: { error: { message: { value: 'Access is denied.' } } },
+        }); // Files(SVD) — denied
+
+      const { files, truncated, skippedFolders } = await service.listTemplateFiles(baseConfig, creds);
+
+      expect(truncated).toBe(false);
+      expect(files).toEqual([]);
+      expect(skippedFolders).toEqual([{ relativePath: 'SVD', reason: 'Access is denied.' }]);
+    });
+
+    test('skips a permission-denied subfolder when the request throws (OAuth-on-onprem 403)', async () => {
+      const service = new SharePointService();
+      const denied: any = new Error('Forbidden');
+      denied.response = { status: 403, headers: {} };
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }) // Files(root)
+        .mockResolvedValueOnce({
+          data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
+        }) // Folders(root)
+        .mockRejectedValueOnce(denied); // Files(SVD) — thrown 403
+
+      const { skippedFolders } = await service.listTemplateFiles(baseConfig, creds);
+
+      expect(skippedFolders).toEqual([{ relativePath: 'SVD', reason: 'Forbidden' }]);
+    });
+
+    test('a subfolder denied only on its Folders fetch keeps its own files but does not descend', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }) // Files(root)
+        .mockResolvedValueOnce({
+          data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
+        }) // Folders(root)
+        .mockResolvedValueOnce({
+          data: {
+            d: {
+              results: [
+                {
+                  Name: 'SVD-template.docx',
+                  ServerRelativeUrl: '/sites/project/Templates/SVD/SVD-template.docx',
+                  TimeLastModified: '2024-01-01T00:00:00Z',
+                  Length: 10,
+                },
+              ],
+            },
+          },
+        }) // Files(SVD) — succeeds
+        .mockResolvedValueOnce({ status: 403, data: { error: { message: { value: 'Access is denied.' } } } }); // Folders(SVD) — denied
+
+      const { files, skippedFolders } = await service.listTemplateFiles(baseConfig, creds);
+
+      expect(files).toHaveLength(1);
+      expect(files[0].name).toBe('SVD-template.docx');
+      expect(skippedFolders).toEqual([{ relativePath: 'SVD', reason: 'Access is denied.' }]);
+    });
+
+    test('a denied connected root (depth 0) always aborts the whole listing, never skips', async () => {
+      const service = new SharePointService();
+      (jest as any).spyOn(service as any, 'makeSharePointRequest').mockResolvedValueOnce({
+        status: 403,
+        data: { error: { message: { value: 'Access is denied.' } } },
+      }); // Files(root) — denied
+
+      await expect(service.listTemplateFiles(baseConfig, creds)).rejects.toThrow(/Access is denied\./);
+    });
+
+    test('a 401 is never tolerated — stays fatal even on a subfolder (credentials are the problem, not the folder)', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }) // Files(root)
+        .mockResolvedValueOnce({
+          data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
+        }) // Folders(root)
+        .mockResolvedValueOnce({
+          status: 401,
+          data: { error: { message: { value: 'Access is denied.' } } },
+        }); // Files(SVD) — 401, must NOT be tolerated despite the "Access is denied." wording
+
+      await expect(service.listTemplateFiles(baseConfig, creds)).rejects.toThrow(/Access is denied\./);
+    });
+
+    test('tolerates a non-403 status whose OData message says access is denied', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }) // Files(root)
+        .mockResolvedValueOnce({
+          data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
+        }) // Folders(root)
+        .mockResolvedValueOnce({
+          status: 500,
+          data: { error: { message: { value: 'You do not have permission to view this directory.' } } },
+        }); // Files(SVD) — non-403 status, denial-shaped message
+
+      const { skippedFolders } = await service.listTemplateFiles(baseConfig, creds);
+
+      expect(skippedFolders).toEqual([
+        { relativePath: 'SVD', reason: 'You do not have permission to view this directory.' },
+      ]);
+    });
+
+    test('a malformed/unrecognized response on a subfolder is still fatal, not skipped (A2 must not weaken this)', async () => {
+      const service = new SharePointService();
+      (jest as any)
+        .spyOn(service as any, 'makeSharePointRequest')
+        .mockResolvedValueOnce({ data: { d: { results: [] } } }) // Files(root)
+        .mockResolvedValueOnce({
+          data: { d: { results: [{ Name: 'SVD', ServerRelativeUrl: '/sites/project/Templates/SVD' }] } },
+        }) // Folders(root)
+        .mockResolvedValueOnce({
+          data: '<feed xmlns="http://www.w3.org/2005/Atom">...</feed>',
+          headers: { 'content-type': 'application/atom+xml' },
+        }); // Files(SVD) — malformed, not a denial shape at all
+
+      await expect(service.listTemplateFiles(baseConfig, creds)).rejects.toThrow(/Unexpected response fetching/);
+    });
+
+    test('caps recorded skippedFolders and notes the true remaining count', async () => {
+      const service = new SharePointService();
+      const subfolderCount = 27; // over MAX_SKIPPED_FOLDERS_RECORDED (25)
+      const subfolders = Array.from({ length: subfolderCount }, (_, i) => ({
+        Name: `Denied${i}`,
+        ServerRelativeUrl: `/sites/project/Templates/Denied${i}`,
+      }));
+
+      const spy = (jest as any).spyOn(service as any, 'makeSharePointRequest');
+      spy.mockResolvedValueOnce({ data: { d: { results: [] } } }); // Files(root)
+      spy.mockResolvedValueOnce({ data: { d: { results: subfolders } } }); // Folders(root)
+      for (let i = 0; i < subfolderCount; i++) {
+        spy.mockResolvedValueOnce({ status: 403, data: { error: { message: { value: 'Access is denied.' } } } });
+      }
+
+      const { skippedFolders } = await service.listTemplateFiles(baseConfig, creds);
+
+      // 25 recorded entries + 1 summary entry for the remaining 2.
+      expect(skippedFolders).toHaveLength(26);
+      expect(skippedFolders[25].reason).toContain('2 more folder(s)');
     });
 
     test('throws descriptive error when makeSharePointRequest fails', async () => {
@@ -323,13 +629,14 @@ describe('SharePointService', () => {
       ];
       const graphSpy = (jest as any)
         .spyOn((service as any).graphService, 'listTemplateFiles')
-        .mockResolvedValueOnce(graphFiles);
+        .mockResolvedValueOnce({ files: graphFiles, truncated: false });
       const restSpy = (jest as any).spyOn(service as any, 'makeSharePointRequest');
 
-      const files = await service.listTemplateFiles(onlineConfig, token);
+      const { files, truncated } = await service.listTemplateFiles(onlineConfig, token);
 
       expect(graphSpy).toHaveBeenCalledWith(onlineConfig.siteUrl, token);
       expect(restSpy).not.toHaveBeenCalled();
+      expect(truncated).toBe(false);
       expect(files).toEqual(graphFiles);
     });
   });
@@ -422,7 +729,8 @@ describe('SharePointService', () => {
       expect(ntlmSpy).toHaveBeenCalledWith(
         'http://sp-server/sites/project/Shared Documents/02 Engineering/Templates/_api/web?$select=ServerRelativeUrl',
         creds,
-        'GET'
+        'GET',
+        { timeout: 15000 }
       );
       expect(result).toEqual({
         siteUrl: 'http://sp-server/sites/project',
@@ -442,7 +750,8 @@ describe('SharePointService', () => {
       expect(ntlmSpy).toHaveBeenCalledWith(
         'http://sp-server/sites/project/Templates/_api/web?$select=ServerRelativeUrl',
         creds,
-        'GET'
+        'GET',
+        { timeout: 15000 }
       );
     });
 
@@ -460,7 +769,8 @@ describe('SharePointService', () => {
       expect(ntlmSpy).toHaveBeenCalledWith(
         'http://elissp/DevOPs/Shared Documents/Forms/AllItems.aspx/_api/web?$select=ServerRelativeUrl',
         creds,
-        'GET'
+        'GET',
+        { timeout: 15000 }
       );
     });
 
@@ -504,21 +814,49 @@ describe('SharePointService', () => {
       expect(rebuilt).toBe('/sites/project/Shared Documents/Templates');
     });
 
-    test('throws a descriptive error when the response has no ServerRelativeUrl', async () => {
+    test('throws a descriptive error when every candidate depth has no ServerRelativeUrl', async () => {
       const service = new SharePointService();
-      (jest as any).spyOn(service as any, 'makeNTLMRequest').mockResolvedValueOnce({
+      // Every candidate (full path down to the bare origin) gets the same
+      // non-matching response — none resolve, so the walk must exhaust all
+      // of them before throwing.
+      const ntlmSpy = (jest as any).spyOn(service as any, 'makeNTLMRequest').mockResolvedValue({
+        status: 404,
         data: '<feed xmlns="http://www.w3.org/2005/Atom">...</feed>',
         headers: { 'content-type': 'application/atom+xml' },
       });
 
       await expect(
         service.resolveSiteFromUrl('http://sp-server/sites/project/Templates', creds)
-      ).rejects.toThrow(/Could not resolve a SharePoint site from this URL/);
+      ).rejects.toThrow(/Unexpected response fetching a SharePoint site for this URL.*status: 404/);
+
+      // 'sites', 'project', 'Templates' -> depths 3,2,1,0 = 4 attempts.
+      expect(ntlmSpy).toHaveBeenCalledTimes(4);
     });
 
-    test('propagates a rejected request as a descriptive error', async () => {
+    test('walks to a shallower candidate when the deepest path 500s (root-web site with a deep folder path)', async () => {
       const service = new SharePointService();
-      (jest as any).spyOn(service as any, 'makeNTLMRequest').mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      const ntlmSpy = (jest as any)
+        .spyOn(service as any, 'makeNTLMRequest')
+        // Deepest candidate (the full pasted path) fails, same as the real
+        // production 500 this fix targets.
+        .mockResolvedValueOnce({ status: 500, data: '', headers: {} })
+        // Bare origin (root web) resolves.
+        .mockResolvedValueOnce({ data: { d: { ServerRelativeUrl: '/' } } });
+
+      const result = await service.resolveSiteFromUrl(
+        'http://elissp/Project/Shared Documents/Training and Templates/DocGen Templates',
+        creds
+      );
+
+      expect(ntlmSpy).toHaveBeenCalledTimes(2);
+      // No doubled trailing slash from ServerRelativeUrl being "/".
+      expect(result.siteUrl).toBe('http://elissp');
+      expect(result.folder).toBe('Project/Shared Documents/Training and Templates/DocGen Templates');
+    });
+
+    test('propagates a rejected request as a descriptive error when every candidate rejects', async () => {
+      const service = new SharePointService();
+      (jest as any).spyOn(service as any, 'makeNTLMRequest').mockRejectedValue(new Error('ECONNREFUSED'));
 
       await expect(
         service.resolveSiteFromUrl('http://sp-server/sites/project/Templates', creds)
@@ -587,6 +925,96 @@ describe('SharePointService', () => {
     });
   });
 
+  describe('makeSharePointRequest throttle retry', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    // Drives fake timers forward while withThrottleRetry is awaiting sleep().
+    async function flushRetries() {
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+        jest.runAllTimers();
+      }
+    }
+
+    test('retries an NTLM 429 response (resolved, not thrown) and succeeds on the next attempt', async () => {
+      const service = new SharePointService();
+      const makeNtlmSpy = (jest as any)
+        .spyOn(service as any, 'makeNTLMRequest')
+        .mockResolvedValueOnce({ status: 429, data: {}, headers: { 'retry-after': '1' } })
+        .mockResolvedValueOnce({ status: 200, data: { ok: true }, headers: {} });
+
+      const promise = (service as any).makeSharePointRequest('http://url', creds, 'GET', {});
+      await flushRetries();
+      const result = await promise;
+
+      expect(result).toEqual({ status: 200, data: { ok: true }, headers: {} });
+      expect(makeNtlmSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('retries a thrown OAuth 429 error and succeeds', async () => {
+      const service = new SharePointService();
+      const err: any = new Error('Too Many Requests');
+      err.response = { status: 429, headers: {} };
+      const makeOAuthSpy = (jest as any)
+        .spyOn(service as any, 'makeOAuthRequest')
+        .mockRejectedValueOnce(err)
+        .mockResolvedValueOnce({ status: 200, data: {}, headers: {} });
+      const token: SharePointOAuthToken = { accessToken: 'token' };
+
+      const promise = (service as any).makeSharePointRequest('http://url', token, 'GET', {});
+      await flushRetries();
+      const result = await promise;
+
+      expect(result.status).toBe(200);
+      expect(makeOAuthSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not retry a non-throttling status (e.g. 404 — a real "not found", not overload)', async () => {
+      const service = new SharePointService();
+      const makeNtlmSpy = (jest as any)
+        .spyOn(service as any, 'makeNTLMRequest')
+        .mockResolvedValue({ status: 404, data: {}, headers: {} });
+
+      const result = await (service as any).makeSharePointRequest('http://url', creds, 'GET', {});
+
+      expect(result.status).toBe(404);
+      expect(makeNtlmSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('defaults a request timeout when the caller does not set one', async () => {
+      const service = new SharePointService();
+      const makeNtlmSpy = (jest as any)
+        .spyOn(service as any, 'makeNTLMRequest')
+        .mockResolvedValueOnce({ status: 200, data: {}, headers: {} });
+
+      await (service as any).makeSharePointRequest('http://url', creds, 'GET', {});
+
+      expect(makeNtlmSpy).toHaveBeenCalledWith(
+        'http://url',
+        creds,
+        'GET',
+        expect.objectContaining({ timeout: 15000 })
+      );
+    });
+
+    test('a caller-supplied timeout wins over the default', async () => {
+      const service = new SharePointService();
+      const makeNtlmSpy = (jest as any)
+        .spyOn(service as any, 'makeNTLMRequest')
+        .mockResolvedValueOnce({ status: 200, data: {}, headers: {} });
+
+      await (service as any).makeSharePointRequest('http://url', creds, 'GET', { timeout: 5000 });
+
+      expect(makeNtlmSpy).toHaveBeenCalledWith('http://url', creds, 'GET', expect.objectContaining({ timeout: 5000 }));
+    });
+  });
+
   describe('toServerRelativeUrlLiteral', () => {
     test('percent-encodes spaces within a segment but leaves "/" as a literal separator', () => {
       const service = new SharePointService();
@@ -627,6 +1055,28 @@ describe('SharePointService', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'Failed to parse SharePoint URL: not-a-url, using root path'
       );
+    });
+
+    test('constructFolderPath adds a leading slash for a root-web site (empty site path)', () => {
+      const service = new SharePointService();
+      const path = (service as any).constructFolderPath({
+        siteUrl: 'http://elissp',
+        library: '',
+        folder: 'Project/Shared Documents/DocGen Templates',
+      });
+
+      expect(path).toBe('/Project/Shared Documents/DocGen Templates');
+    });
+
+    test('constructFolderPath is unaffected for a /sites/x site (already has a leading slash)', () => {
+      const service = new SharePointService();
+      const path = (service as any).constructFolderPath({
+        siteUrl: 'http://sp-server/sites/project',
+        library: 'Shared Documents',
+        folder: 'Templates',
+      });
+
+      expect(path).toBe('/sites/project/Shared Documents/Templates');
     });
 
     test('makeOAuthRequest sends bearer token and merges headers', async () => {

--- a/src/test/services/auth/IdTokenValidator.test.ts
+++ b/src/test/services/auth/IdTokenValidator.test.ts
@@ -1,0 +1,38 @@
+import { assertIdTokenClaims } from '../../../services/auth/IdTokenValidator';
+
+describe('assertIdTokenClaims', () => {
+  const expected = { nonce: 'expected-nonce', tenantId: 'expected-tenant', clientId: 'expected-client' };
+  const validClaims = { nonce: 'expected-nonce', tid: 'expected-tenant', aud: 'expected-client' };
+
+  test('does not throw when every claim matches', () => {
+    expect(() => assertIdTokenClaims(validClaims, expected)).not.toThrow();
+  });
+
+  test('throws on a nonce mismatch', () => {
+    expect(() => assertIdTokenClaims({ ...validClaims, nonce: 'wrong' }, expected)).toThrow(/nonce mismatch/i);
+  });
+
+  test('throws when nonce is missing', () => {
+    expect(() => assertIdTokenClaims({ ...validClaims, nonce: undefined }, expected)).toThrow(/nonce mismatch/i);
+  });
+
+  test('throws on a tenant mismatch', () => {
+    expect(() => assertIdTokenClaims({ ...validClaims, tid: 'wrong-tenant' }, expected)).toThrow(/tenant mismatch/i);
+  });
+
+  test('throws when tid is missing', () => {
+    expect(() => assertIdTokenClaims({ ...validClaims, tid: undefined }, expected)).toThrow(/tenant mismatch/i);
+  });
+
+  test('throws on an audience mismatch', () => {
+    expect(() => assertIdTokenClaims({ ...validClaims, aud: 'wrong-client' }, expected)).toThrow(/audience mismatch/i);
+  });
+
+  test('throws when aud is missing', () => {
+    expect(() => assertIdTokenClaims({ ...validClaims, aud: undefined }, expected)).toThrow(/audience mismatch/i);
+  });
+
+  test('checks nonce before tenant before audience (fails on the first bad claim encountered)', () => {
+    expect(() => assertIdTokenClaims({ nonce: 'wrong', tid: 'wrong-too', aud: 'wrong-also' }, expected)).toThrow(/nonce mismatch/i);
+  });
+});

--- a/src/test/services/auth/MongoTokenCachePlugin.test.ts
+++ b/src/test/services/auth/MongoTokenCachePlugin.test.ts
@@ -1,0 +1,118 @@
+jest.mock('../../../models/MsalTokenCache', () => ({
+  __esModule: true,
+  MsalTokenCache: {
+    findOne: jest.fn(),
+    findOneAndUpdate: jest.fn(),
+  },
+}));
+jest.mock('../../../util/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+import { MsalTokenCache } from '../../../models/MsalTokenCache';
+import logger from '../../../util/logger';
+import { MongoCacheClient, HomeAccountPartitionManager } from '../../../services/auth/MongoTokenCachePlugin';
+import { resetAuthConfigCacheForTests } from '../../../util/authConfig';
+import { encryptCacheBlob } from '../../../util/tokenCacheCipher';
+
+const mockFindOne = MsalTokenCache.findOne as jest.Mock;
+const mockFindOneAndUpdate = MsalTokenCache.findOneAndUpdate as jest.Mock;
+
+describe('MongoCacheClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetAuthConfigCacheForTests();
+    process.env.CLIENT_ID = 'client';
+    process.env.TENANT_ID = 'tenant';
+    process.env.CLIENT_SECRET = 'secret';
+    process.env.REDIRECT_URI = 'https://docgen.example.com/auth/callback';
+    process.env.SESSION_SECRET = 'e'.repeat(32);
+  });
+
+  describe('get', () => {
+    test('returns an empty string for an empty key without querying the database (fresh-code-redemption case)', async () => {
+      const client = new MongoCacheClient();
+      const result = await client.get('');
+      expect(result).toBe('');
+      expect(mockFindOne).not.toHaveBeenCalled();
+    });
+
+    test('returns an empty string when no cache row exists for the partition', async () => {
+      mockFindOne.mockResolvedValueOnce(null);
+      const client = new MongoCacheClient();
+      expect(await client.get('home-1')).toBe('');
+    });
+
+    test('decrypts and returns the cached blob for a known partition', async () => {
+      const blob = encryptCacheBlob('{"Account":{}}');
+      mockFindOne.mockResolvedValueOnce({
+        ciphertext: blob.ciphertext,
+        iv: blob.iv,
+        authTag: blob.authTag,
+        keyVersion: blob.keyVersion,
+      });
+
+      const client = new MongoCacheClient();
+      const result = await client.get('home-1');
+
+      expect(result).toBe('{"Account":{}}');
+      expect(mockFindOne).toHaveBeenCalledWith({ homeAccountId: 'home-1' });
+    });
+
+    test('treats a corrupted/tampered blob as a cache miss (fails closed, not a thrown error)', async () => {
+      mockFindOne.mockResolvedValueOnce({
+        ciphertext: 'not-valid-base64-ciphertext!!',
+        iv: 'AAAAAAAAAAAAAAAA',
+        authTag: 'AAAAAAAAAAAAAAAAAAAAAA==',
+        keyVersion: 1,
+      });
+
+      const client = new MongoCacheClient();
+      const result = await client.get('home-1');
+
+      expect(result).toBe('');
+      expect((logger.error as jest.Mock)).toHaveBeenCalled();
+    });
+  });
+
+  describe('set', () => {
+    test('returns the input value without writing when the key is empty', async () => {
+      const client = new MongoCacheClient();
+      const result = await client.set('', 'some-cache-blob');
+      expect(result).toBe('some-cache-blob');
+      expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('upserts an encrypted blob under the given partition key', async () => {
+      mockFindOneAndUpdate.mockResolvedValueOnce({});
+      const client = new MongoCacheClient();
+
+      await client.set('home-1', '{"Account":{}}');
+
+      const [[query, update, options]] = mockFindOneAndUpdate.mock.calls;
+      expect(query).toEqual({ homeAccountId: 'home-1' });
+      expect(options).toEqual({ upsert: true });
+      expect(update.$set.ciphertext).toBeDefined();
+      expect(update.$set.ciphertext).not.toContain('Account');
+      expect(update.$set.expiresAt).toBeInstanceOf(Date);
+    });
+  });
+});
+
+describe('HomeAccountPartitionManager', () => {
+  test('getKey returns the known homeAccountId when constructed with one', async () => {
+    const manager = new HomeAccountPartitionManager('home-1');
+    expect(await manager.getKey()).toBe('home-1');
+  });
+
+  test('getKey returns an empty string when no homeAccountId is known yet (fresh code redemption)', async () => {
+    const manager = new HomeAccountPartitionManager();
+    expect(await manager.getKey()).toBe('');
+  });
+
+  test('extractKey returns the homeAccountId from the account entity, regardless of the known key', async () => {
+    const manager = new HomeAccountPartitionManager();
+    expect(await manager.extractKey({ homeAccountId: 'discovered-home-id' })).toBe('discovered-home-id');
+  });
+});

--- a/src/test/services/auth/MsalClientService.test.ts
+++ b/src/test/services/auth/MsalClientService.test.ts
@@ -1,0 +1,187 @@
+const mockGetAuthCodeUrl = jest.fn();
+const mockAcquireTokenByCode = jest.fn();
+const mockAcquireTokenSilent = jest.fn();
+const mockGetAccountByHomeId = jest.fn();
+const mockCcaConstructor = jest.fn();
+
+class FakeInteractionRequiredAuthError extends Error {}
+
+jest.mock('@azure/msal-node', () => ({
+  __esModule: true,
+  ConfidentialClientApplication: jest.fn().mockImplementation((config: any) => {
+    mockCcaConstructor(config);
+    return {
+      getAuthCodeUrl: mockGetAuthCodeUrl,
+      acquireTokenByCode: mockAcquireTokenByCode,
+      acquireTokenSilent: mockAcquireTokenSilent,
+      getTokenCache: () => ({ getAccountByHomeId: mockGetAccountByHomeId }),
+    };
+  }),
+  InteractionRequiredAuthError: FakeInteractionRequiredAuthError,
+}));
+
+jest.mock('../../../services/auth/MongoTokenCachePlugin', () => ({
+  __esModule: true,
+  createPartitionedCachePlugin: jest.fn().mockReturnValue({ cachePlugin: {}, partitionManager: {} }),
+}));
+
+import { buildAuthCodeUrl, redeemAuthCode, createTokenProvider, ReauthRequiredError } from '../../../services/auth/MsalClientService';
+import { resetAuthConfigCacheForTests } from '../../../util/authConfig';
+import { createPartitionedCachePlugin } from '../../../services/auth/MongoTokenCachePlugin';
+
+describe('MsalClientService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetAuthConfigCacheForTests();
+    process.env.CLIENT_ID = 'the-client-id';
+    process.env.TENANT_ID = 'the-tenant-id';
+    process.env.CLIENT_SECRET = 'the-client-secret';
+    process.env.REDIRECT_URI = 'https://docgen.example.com/auth/callback';
+    process.env.SESSION_SECRET = 'f'.repeat(32);
+  });
+
+  describe('buildAuthCodeUrl', () => {
+    test('requests the exact scope set: openid, profile, offline_access, Files.Read.All — no User.Read, no write scopes', async () => {
+      mockGetAuthCodeUrl.mockResolvedValueOnce('https://login.microsoftonline.com/authorize?...');
+
+      await buildAuthCodeUrl({ state: 'state-1', nonce: 'nonce-1', codeVerifier: 'verifier-1' });
+
+      const [[request]] = mockGetAuthCodeUrl.mock.calls;
+      expect(request.scopes).toEqual([
+        'openid',
+        'profile',
+        'offline_access',
+        'https://graph.microsoft.com/Files.Read.All',
+      ]);
+      expect(request.scopes).not.toContain('https://graph.microsoft.com/User.Read');
+      expect(request.scopes.some((s: string) => /ReadWrite/.test(s))).toBe(false);
+    });
+
+    test('computes an S256 code challenge from the verifier and never sends the verifier itself', async () => {
+      mockGetAuthCodeUrl.mockResolvedValueOnce('https://login.microsoftonline.com/authorize?...');
+
+      await buildAuthCodeUrl({ state: 'state-1', nonce: 'nonce-1', codeVerifier: 'my-secret-verifier' });
+
+      const [[request]] = mockGetAuthCodeUrl.mock.calls;
+      expect(request.codeChallengeMethod).toBe('S256');
+      expect(request.codeChallenge).toBeDefined();
+      expect(request.codeChallenge).not.toBe('my-secret-verifier');
+    });
+
+    test('passes state, nonce, and the configured redirectUri through', async () => {
+      mockGetAuthCodeUrl.mockResolvedValueOnce('https://login.microsoftonline.com/authorize?...');
+
+      await buildAuthCodeUrl({ state: 'state-1', nonce: 'nonce-1', codeVerifier: 'verifier-1' });
+
+      const [[request]] = mockGetAuthCodeUrl.mock.calls;
+      expect(request.state).toBe('state-1');
+      expect(request.nonce).toBe('nonce-1');
+      expect(request.redirectUri).toBe('https://docgen.example.com/auth/callback');
+    });
+
+    test('builds the CCA with no known homeAccountId (nothing to load for a not-yet-authenticated user)', async () => {
+      mockGetAuthCodeUrl.mockResolvedValueOnce('https://login.microsoftonline.com/authorize?...');
+
+      await buildAuthCodeUrl({ state: 's', nonce: 'n', codeVerifier: 'v' });
+
+      expect(createPartitionedCachePlugin).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('redeemAuthCode', () => {
+    test('exchanges the code with the same scope set and the provided codeVerifier', async () => {
+      mockAcquireTokenByCode.mockResolvedValueOnce({ account: { homeAccountId: 'home-1' } });
+
+      await redeemAuthCode({ code: 'auth-code-1', codeVerifier: 'verifier-1', state: 'state-1' });
+
+      const [[request]] = mockAcquireTokenByCode.mock.calls;
+      expect(request.code).toBe('auth-code-1');
+      expect(request.codeVerifier).toBe('verifier-1');
+      expect(request.state).toBe('state-1');
+      expect(request.scopes).toEqual([
+        'openid',
+        'profile',
+        'offline_access',
+        'https://graph.microsoft.com/Files.Read.All',
+      ]);
+    });
+
+    test('returns the full AuthenticationResult from MSAL', async () => {
+      const fakeResult = { account: { homeAccountId: 'home-1' }, accessToken: 'abc' };
+      mockAcquireTokenByCode.mockResolvedValueOnce(fakeResult);
+
+      const result = await redeemAuthCode({ code: 'c', codeVerifier: 'v' });
+
+      expect(result).toBe(fakeResult);
+    });
+  });
+
+  describe('createTokenProvider', () => {
+    test('builds the CCA scoped to the given homeAccountId', async () => {
+      mockGetAccountByHomeId.mockResolvedValueOnce({ homeAccountId: 'home-1' });
+      mockAcquireTokenSilent.mockResolvedValueOnce({ accessToken: 'graph-token-1' });
+
+      const provider = createTokenProvider('home-1');
+      await provider();
+
+      expect(createPartitionedCachePlugin).toHaveBeenCalledWith('home-1');
+    });
+
+    test('throws ReauthRequiredError when no cached account exists for the homeAccountId', async () => {
+      mockGetAccountByHomeId.mockResolvedValueOnce(null);
+
+      const provider = createTokenProvider('home-1');
+
+      await expect(provider()).rejects.toThrow(ReauthRequiredError);
+    });
+
+    test('returns the fresh access token on a successful silent refresh, only requesting the Graph resource scope', async () => {
+      mockGetAccountByHomeId.mockResolvedValueOnce({ homeAccountId: 'home-1' });
+      mockAcquireTokenSilent.mockResolvedValueOnce({ accessToken: 'graph-token-1' });
+
+      const provider = createTokenProvider('home-1');
+      const token = await provider();
+
+      expect(token).toBe('graph-token-1');
+      const [[request]] = mockAcquireTokenSilent.mock.calls;
+      expect(request.scopes).toEqual(['https://graph.microsoft.com/Files.Read.All']);
+    });
+
+    test('maps InteractionRequiredAuthError to ReauthRequiredError', async () => {
+      mockGetAccountByHomeId.mockResolvedValueOnce({ homeAccountId: 'home-1' });
+      mockAcquireTokenSilent.mockRejectedValueOnce(new FakeInteractionRequiredAuthError('consent expired'));
+
+      const provider = createTokenProvider('home-1');
+
+      await expect(provider()).rejects.toThrow(ReauthRequiredError);
+    });
+
+    test('propagates an unrelated error unchanged', async () => {
+      mockGetAccountByHomeId.mockResolvedValueOnce({ homeAccountId: 'home-1' });
+      mockAcquireTokenSilent.mockRejectedValueOnce(new Error('network down'));
+
+      const provider = createTokenProvider('home-1');
+
+      await expect(provider()).rejects.toThrow('network down');
+    });
+
+    // Regression test for the bug this design specifically fixes:
+    // syncTemplates used to capture ONE token/credentials object and reuse
+    // it across a whole download loop that could outlive a 60-90 minute
+    // access token. createTokenProvider's whole purpose is that EVERY
+    // invocation re-acquires (MSAL itself decides whether that's a cache
+    // hit or a real network refresh) — assert it is actually called once
+    // per invocation, not cached by this layer.
+    test('calls acquireTokenSilent once per invocation, not once total across multiple calls', async () => {
+      mockGetAccountByHomeId.mockResolvedValue({ homeAccountId: 'home-1' });
+      mockAcquireTokenSilent.mockResolvedValue({ accessToken: 'graph-token-1' });
+
+      const provider = createTokenProvider('home-1');
+      await provider();
+      await provider();
+      await provider();
+
+      expect(mockAcquireTokenSilent).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/src/test/services/auth/OAuthTransactionService.test.ts
+++ b/src/test/services/auth/OAuthTransactionService.test.ts
@@ -1,0 +1,115 @@
+jest.mock('../../../models/OAuthTransaction', () => ({
+  __esModule: true,
+  OAuthTransaction: {
+    create: jest.fn(),
+    findOneAndDelete: jest.fn(),
+  },
+}));
+
+import { OAuthTransaction } from '../../../models/OAuthTransaction';
+import { createTransaction, consumeTransaction } from '../../../services/auth/OAuthTransactionService';
+
+const mockCreate = OAuthTransaction.create as jest.Mock;
+const mockFindOneAndDelete = OAuthTransaction.findOneAndDelete as jest.Mock;
+
+describe('OAuthTransactionService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createTransaction', () => {
+    test('persists a transaction with the requested openerOrigin and transport', async () => {
+      mockCreate.mockResolvedValueOnce({});
+
+      const result = await createTransaction({ openerOrigin: 'https://docgen.example.com', transport: 'cookie' });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          openerOrigin: 'https://docgen.example.com',
+          transport: 'cookie',
+          state: expect.any(String),
+          codeVerifier: expect.any(String),
+          nonce: expect.any(String),
+          expiresAt: expect.any(Date),
+        })
+      );
+      expect(result.openerOrigin).toBe('https://docgen.example.com');
+      expect(result.transport).toBe('cookie');
+    });
+
+    test('generates a different state/codeVerifier/nonce on each call', async () => {
+      mockCreate.mockResolvedValue({});
+
+      const first = await createTransaction({ openerOrigin: 'https://a.example.com', transport: 'bearer' });
+      const second = await createTransaction({ openerOrigin: 'https://a.example.com', transport: 'bearer' });
+
+      expect(first.state).not.toBe(second.state);
+      expect(first.codeVerifier).not.toBe(second.codeVerifier);
+      expect(first.nonce).not.toBe(second.nonce);
+    });
+
+    test('sets an expiresAt roughly 10 minutes in the future', async () => {
+      mockCreate.mockResolvedValueOnce({});
+      const before = Date.now();
+
+      await createTransaction({ openerOrigin: 'https://a.example.com', transport: 'cookie' });
+
+      const [[callArgs]] = mockCreate.mock.calls;
+      const expiresAtMs = (callArgs.expiresAt as Date).getTime();
+      expect(expiresAtMs).toBeGreaterThan(before + 9 * 60 * 1000);
+      expect(expiresAtMs).toBeLessThan(before + 11 * 60 * 1000);
+    });
+  });
+
+  describe('consumeTransaction', () => {
+    test('returns the transaction fields when found', async () => {
+      mockFindOneAndDelete.mockResolvedValueOnce({
+        state: 'state-1',
+        codeVerifier: 'verifier-1',
+        nonce: 'nonce-1',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'cookie',
+      });
+
+      const result = await consumeTransaction('state-1');
+
+      expect(mockFindOneAndDelete).toHaveBeenCalledWith({ state: 'state-1', expiresAt: { $gt: expect.any(Date) } });
+      expect(result).toEqual({
+        state: 'state-1',
+        codeVerifier: 'verifier-1',
+        nonce: 'nonce-1',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'cookie',
+      });
+    });
+
+    test('returns null when no matching, unexpired transaction exists', async () => {
+      mockFindOneAndDelete.mockResolvedValueOnce(null);
+
+      const result = await consumeTransaction('unknown-state');
+
+      expect(result).toBeNull();
+    });
+
+    // Regression: a second consume of the same state must find nothing —
+    // findOneAndDelete already removed the row on the first call, so replay
+    // is impossible by construction, not by an application-level check.
+    test('a second consume of the same state (simulating replay) finds nothing', async () => {
+      mockFindOneAndDelete.mockResolvedValueOnce({
+        state: 'state-2',
+        codeVerifier: 'v',
+        nonce: 'n',
+        openerOrigin: 'https://docgen.example.com',
+        transport: 'cookie',
+      });
+      mockFindOneAndDelete.mockResolvedValueOnce(null);
+
+      const first = await consumeTransaction('state-2');
+      const second = await consumeTransaction('state-2');
+
+      expect(first).not.toBeNull();
+      expect(second).toBeNull();
+      expect(mockFindOneAndDelete).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/test/services/auth/SessionService.test.ts
+++ b/src/test/services/auth/SessionService.test.ts
@@ -1,0 +1,215 @@
+jest.mock('../../../models/AuthSession', () => ({
+  __esModule: true,
+  AuthSession: {
+    create: jest.fn(),
+    findOneAndUpdate: jest.fn(),
+    findOneAndDelete: jest.fn(),
+    findOne: jest.fn(),
+  },
+}));
+jest.mock('../../../models/SessionHandleCode', () => ({
+  __esModule: true,
+  SessionHandleCode: {
+    create: jest.fn(),
+    findOneAndDelete: jest.fn(),
+  },
+}));
+jest.mock('../../../models/MsalTokenCache', () => ({
+  __esModule: true,
+  MsalTokenCache: {
+    deleteOne: jest.fn(),
+  },
+}));
+
+import { AuthSession } from '../../../models/AuthSession';
+import { SessionHandleCode } from '../../../models/SessionHandleCode';
+import { MsalTokenCache } from '../../../models/MsalTokenCache';
+import {
+  createSession,
+  resolveSession,
+  revokeSession,
+  verifyCsrf,
+  issueHandleCode,
+  consumeHandleCode,
+} from '../../../services/auth/SessionService';
+import { hashToken } from '../../../util/randomTokens';
+
+const mockAuthSessionCreate = AuthSession.create as jest.Mock;
+const mockAuthSessionFindOneAndUpdate = AuthSession.findOneAndUpdate as jest.Mock;
+const mockAuthSessionFindOneAndDelete = AuthSession.findOneAndDelete as jest.Mock;
+const mockAuthSessionFindOne = AuthSession.findOne as jest.Mock;
+const mockHandleCodeCreate = SessionHandleCode.create as jest.Mock;
+const mockHandleCodeFindOneAndDelete = SessionHandleCode.findOneAndDelete as jest.Mock;
+const mockMsalCacheDeleteOne = MsalTokenCache.deleteOne as jest.Mock;
+
+describe('SessionService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CLIENT_ID = 'client';
+    process.env.TENANT_ID = 'tenant';
+    process.env.CLIENT_SECRET = 'secret';
+    process.env.REDIRECT_URI = 'https://docgen.example.com/auth/callback';
+    process.env.SESSION_SECRET = 'd'.repeat(32);
+  });
+
+  describe('createSession', () => {
+    test('persists only the hash of the session token and csrf token, never the raw values', async () => {
+      mockAuthSessionCreate.mockResolvedValueOnce({});
+
+      const { sessionToken, csrfToken } = await createSession({ homeAccountId: 'home-1', transport: 'cookie' });
+
+      const [[callArgs]] = mockAuthSessionCreate.mock.calls;
+      expect(callArgs.sessionTokenHash).toBe(hashToken(sessionToken));
+      expect(callArgs.csrfTokenHash).toBe(hashToken(csrfToken));
+      expect(JSON.stringify(callArgs)).not.toContain(sessionToken);
+      expect(JSON.stringify(callArgs)).not.toContain(csrfToken);
+    });
+
+    test('sets idle expiry to ~60 minutes and absolute expiry to ~8 hours from now', async () => {
+      mockAuthSessionCreate.mockResolvedValueOnce({});
+      const before = Date.now();
+
+      await createSession({ homeAccountId: 'home-1', transport: 'cookie' });
+
+      const [[callArgs]] = mockAuthSessionCreate.mock.calls;
+      expect((callArgs.idleExpiresAt as Date).getTime() - before).toBeCloseTo(60 * 60 * 1000, -3);
+      expect((callArgs.absoluteExpiresAt as Date).getTime() - before).toBeCloseTo(8 * 60 * 60 * 1000, -3);
+    });
+
+    test('carries through the optional ID-token-derived fields', async () => {
+      mockAuthSessionCreate.mockResolvedValueOnce({});
+
+      await createSession({
+        homeAccountId: 'home-1',
+        transport: 'bearer',
+        displayName: 'Eden Zvi Schwartz',
+        userPrincipalName: 'eden@korentec.onmicrosoft.com',
+        tenantId: 'tenant-guid',
+      });
+
+      const [[callArgs]] = mockAuthSessionCreate.mock.calls;
+      expect(callArgs).toMatchObject({
+        displayName: 'Eden Zvi Schwartz',
+        userPrincipalName: 'eden@korentec.onmicrosoft.com',
+        tenantId: 'tenant-guid',
+        transport: 'bearer',
+      });
+    });
+  });
+
+  describe('resolveSession', () => {
+    test('returns null immediately for an empty token without querying the database', async () => {
+      const result = await resolveSession('');
+      expect(result).toBeNull();
+      expect(mockAuthSessionFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('returns null when no live (unexpired) session matches', async () => {
+      mockAuthSessionFindOneAndUpdate.mockResolvedValueOnce(null);
+      const result = await resolveSession('some-raw-token');
+      expect(result).toBeNull();
+    });
+
+    test('returns the session and slides idleExpiresAt forward on a hit', async () => {
+      mockAuthSessionFindOneAndUpdate.mockResolvedValueOnce({
+        _id: 'mongo-id-1',
+        homeAccountId: 'home-1',
+        transport: 'cookie',
+        displayName: 'Eden',
+        userPrincipalName: 'eden@korentec.onmicrosoft.com',
+      });
+
+      const result = await resolveSession('raw-token');
+
+      expect(result).toEqual({
+        sessionId: 'mongo-id-1',
+        homeAccountId: 'home-1',
+        transport: 'cookie',
+        displayName: 'Eden',
+        userPrincipalName: 'eden@korentec.onmicrosoft.com',
+      });
+      const [[query, update]] = mockAuthSessionFindOneAndUpdate.mock.calls;
+      expect(query.sessionTokenHash).toBe(hashToken('raw-token'));
+      expect(update.$set.idleExpiresAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('revokeSession', () => {
+    test('deletes the session and its MSAL token cache row', async () => {
+      mockAuthSessionFindOneAndDelete.mockResolvedValueOnce({ homeAccountId: 'home-1' });
+
+      await revokeSession('raw-token');
+
+      expect(mockAuthSessionFindOneAndDelete).toHaveBeenCalledWith({ sessionTokenHash: hashToken('raw-token') });
+      expect(mockMsalCacheDeleteOne).toHaveBeenCalledWith({ homeAccountId: 'home-1' });
+    });
+
+    test('does nothing to the token cache when no session was found', async () => {
+      mockAuthSessionFindOneAndDelete.mockResolvedValueOnce(null);
+
+      await revokeSession('raw-token');
+
+      expect(mockMsalCacheDeleteOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('verifyCsrf', () => {
+    test('returns false when no session matches the raw session token', async () => {
+      mockAuthSessionFindOne.mockResolvedValueOnce(null);
+      expect(await verifyCsrf('raw-session-token', 'csrf-token')).toBe(false);
+    });
+
+    test('returns true when the csrf token hash matches', async () => {
+      mockAuthSessionFindOne.mockResolvedValueOnce({ csrfTokenHash: hashToken('correct-csrf') });
+      expect(await verifyCsrf('raw-session-token', 'correct-csrf')).toBe(true);
+    });
+
+    test('returns false when the csrf token hash does not match', async () => {
+      mockAuthSessionFindOne.mockResolvedValueOnce({ csrfTokenHash: hashToken('correct-csrf') });
+      expect(await verifyCsrf('raw-session-token', 'wrong-csrf')).toBe(false);
+    });
+  });
+
+  describe('issueHandleCode / consumeHandleCode', () => {
+    test('issueHandleCode encrypts the raw session token, never storing it in plaintext', async () => {
+      mockHandleCodeCreate.mockResolvedValueOnce({});
+
+      await issueHandleCode('the-raw-session-token');
+
+      const [[callArgs]] = mockHandleCodeCreate.mock.calls;
+      expect(callArgs.sessionTokenCiphertext).toBeDefined();
+      expect(callArgs.sessionTokenCiphertext).not.toContain('the-raw-session-token');
+      expect(callArgs.expiresAt.getTime() - Date.now()).toBeLessThanOrEqual(60 * 1000 + 100);
+    });
+
+    test('consumeHandleCode decrypts and returns the original raw session token', async () => {
+      let capturedBlob: any;
+      mockHandleCodeCreate.mockImplementationOnce((args: any) => {
+        capturedBlob = args;
+        return Promise.resolve({});
+      });
+
+      const code = await issueHandleCode('the-raw-session-token');
+
+      mockHandleCodeFindOneAndDelete.mockResolvedValueOnce({
+        sessionTokenCiphertext: capturedBlob.sessionTokenCiphertext,
+        sessionTokenIv: capturedBlob.sessionTokenIv,
+        sessionTokenAuthTag: capturedBlob.sessionTokenAuthTag,
+        sessionTokenKeyVersion: capturedBlob.sessionTokenKeyVersion,
+      });
+
+      const result = await consumeHandleCode(code);
+
+      expect(result).toEqual({ sessionToken: 'the-raw-session-token' });
+      expect(mockHandleCodeFindOneAndDelete).toHaveBeenCalledWith({
+        codeHash: hashToken(code),
+        expiresAt: { $gt: expect.any(Date) },
+      });
+    });
+
+    test('consumeHandleCode returns null when the code is unknown or already consumed', async () => {
+      mockHandleCodeFindOneAndDelete.mockResolvedValueOnce(null);
+      expect(await consumeHandleCode('unknown-code')).toBeNull();
+    });
+  });
+});

--- a/src/test/services/sharePointFileValidation.test.ts
+++ b/src/test/services/sharePointFileValidation.test.ts
@@ -1,0 +1,72 @@
+import {
+  isTemplateFileName,
+  isWithinMaxTemplateSize,
+  hasZipSignature,
+  MAX_TEMPLATE_FILE_SIZE_BYTES,
+} from '../../services/sharePointFileValidation';
+
+describe('isTemplateFileName', () => {
+  test('accepts .docx and .dotx files', () => {
+    expect(isTemplateFileName('SVD-template.docx')).toBe(true);
+    expect(isTemplateFileName('STD-template.dotx')).toBe(true);
+  });
+
+  test('is case-insensitive on the extension', () => {
+    expect(isTemplateFileName('Template.DOCX')).toBe(true);
+  });
+
+  test('rejects a real Word/Excel lock file even though it ends in .dotx', () => {
+    // Matches the actual seed asset found in this repo:
+    // s3-initializer/assets/templates/shared/SVD/~$ftware Version Description.dotx
+    expect(isTemplateFileName('~$ftware Version Description.dotx')).toBe(false);
+  });
+
+  test('rejects non-template extensions', () => {
+    expect(isTemplateFileName('notes.txt')).toBe(false);
+    expect(isTemplateFileName('image.png')).toBe(false);
+  });
+
+  test('rejects empty/undefined names rather than throwing', () => {
+    expect(isTemplateFileName('')).toBe(false);
+    expect(isTemplateFileName(undefined as unknown as string)).toBe(false);
+  });
+});
+
+describe('isWithinMaxTemplateSize', () => {
+  test('accepts a normal-sized file', () => {
+    expect(isWithinMaxTemplateSize(1024)).toBe(true);
+  });
+
+  test('accepts exactly the size ceiling', () => {
+    expect(isWithinMaxTemplateSize(MAX_TEMPLATE_FILE_SIZE_BYTES)).toBe(true);
+  });
+
+  test('rejects a file over the size ceiling', () => {
+    expect(isWithinMaxTemplateSize(MAX_TEMPLATE_FILE_SIZE_BYTES + 1)).toBe(false);
+  });
+
+  test('rejects a zero-byte file', () => {
+    expect(isWithinMaxTemplateSize(0)).toBe(false);
+  });
+
+  test('rejects a non-numeric size rather than throwing', () => {
+    expect(isWithinMaxTemplateSize(NaN)).toBe(false);
+    expect(isWithinMaxTemplateSize(undefined as unknown as number)).toBe(false);
+  });
+});
+
+describe('hasZipSignature', () => {
+  test('accepts a buffer starting with the ZIP local-file-header signature', () => {
+    const buffer = Buffer.concat([Buffer.from([0x50, 0x4b, 0x03, 0x04]), Buffer.from('rest of the file')]);
+    expect(hasZipSignature(buffer)).toBe(true);
+  });
+
+  test('rejects a plain-text buffer', () => {
+    expect(hasZipSignature(Buffer.from('not a real docx'))).toBe(false);
+  });
+
+  test('rejects a buffer shorter than 4 bytes rather than throwing', () => {
+    expect(hasZipSignature(Buffer.from([0x50, 0x4b]))).toBe(false);
+    expect(hasZipSignature(Buffer.alloc(0))).toBe(false);
+  });
+});

--- a/src/test/services/sharePointRetry.test.ts
+++ b/src/test/services/sharePointRetry.test.ts
@@ -1,0 +1,185 @@
+import {
+  parseRetryAfterMs,
+  backoffDelayMs,
+  withThrottleRetry,
+  createRetryBudget,
+  MAX_RETRY_AFTER_MS,
+  MAX_RETRY_ATTEMPTS,
+  BASE_BACKOFF_MS,
+} from '../../services/sharePointRetry';
+
+jest.mock('../../util/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+describe('parseRetryAfterMs', () => {
+  test('parses delta-seconds', () => {
+    expect(parseRetryAfterMs('2')).toBe(2000);
+  });
+
+  test('parses an HTTP-date in the future', () => {
+    const future = new Date(Date.now() + 3000).toUTCString();
+    const result = parseRetryAfterMs(future);
+    expect(result).not.toBeNull();
+    expect(result as number).toBeGreaterThan(2000);
+    expect(result as number).toBeLessThanOrEqual(3000);
+  });
+
+  test('clamps a hostile/huge value to MAX_RETRY_AFTER_MS', () => {
+    expect(parseRetryAfterMs('999999')).toBe(MAX_RETRY_AFTER_MS);
+  });
+
+  test('returns 0, not negative, for a past HTTP-date', () => {
+    const past = new Date(Date.now() - 5000).toUTCString();
+    expect(parseRetryAfterMs(past)).toBe(0);
+  });
+
+  test('returns null for garbage input', () => {
+    expect(parseRetryAfterMs('not-a-date-or-number')).toBeNull();
+  });
+
+  test('returns null when absent', () => {
+    expect(parseRetryAfterMs(undefined)).toBeNull();
+  });
+});
+
+describe('backoffDelayMs', () => {
+  test('prefers Retry-After over exponential backoff', () => {
+    expect(backoffDelayMs(0, '3')).toBe(3000);
+  });
+
+  test('falls back to exponential backoff when no header', () => {
+    expect(backoffDelayMs(0)).toBe(BASE_BACKOFF_MS);
+    expect(backoffDelayMs(1)).toBe(BASE_BACKOFF_MS * 2);
+  });
+});
+
+describe('withThrottleRetry', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // Drives fake timers forward while a retry loop is awaiting sleep().
+  async function flushRetries() {
+    for (let i = 0; i < MAX_RETRY_ATTEMPTS + 1; i++) {
+      await Promise.resolve();
+      jest.runAllTimers();
+    }
+  }
+
+  test('succeeds on the first attempt with no retry', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const classify = jest.fn().mockReturnValue({ retryable: false });
+
+    const result = await withThrottleRetry(fn, classify);
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries a resolved 429-shaped outcome then succeeds', async () => {
+    const fn = jest
+      .fn()
+      .mockResolvedValueOnce({ status: 429, headers: { 'retry-after': '1' } })
+      .mockResolvedValueOnce({ status: 200, data: 'done' });
+    const classify = jest.fn((outcome) => ({
+      retryable: outcome.value?.status === 429,
+      retryAfter: outcome.value?.headers?.['retry-after'],
+    }));
+
+    const promise = withThrottleRetry(fn, classify);
+    await flushRetries();
+    const result = await promise;
+
+    expect(result).toEqual({ status: 200, data: 'done' });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('retries a thrown 429 error then succeeds', async () => {
+    const thrownError: any = new Error('Too Many Requests');
+    thrownError.response = { status: 429, headers: {} };
+    const fn = jest.fn().mockRejectedValueOnce(thrownError).mockResolvedValueOnce('ok');
+    const classify = jest.fn((outcome) => ({
+      retryable: outcome.error?.response?.status === 429,
+      retryAfter: outcome.error?.response?.headers?.['retry-after'],
+    }));
+
+    const promise = withThrottleRetry(fn, classify);
+    await flushRetries();
+    const result = await promise;
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('gives up after MAX_RETRY_ATTEMPTS and surfaces the last outcome', async () => {
+    const fn = jest.fn().mockResolvedValue({ status: 503 });
+    const classify = jest.fn().mockReturnValue({ retryable: true });
+
+    const promise = withThrottleRetry(fn, classify);
+    await flushRetries();
+    const result = await promise;
+
+    expect(result).toEqual({ status: 503 });
+    expect(fn).toHaveBeenCalledTimes(MAX_RETRY_ATTEMPTS + 1);
+  });
+
+  test('gives up and rethrows after MAX_RETRY_ATTEMPTS when the outcome is a thrown error', async () => {
+    const err: any = new Error('still throttled');
+    err.response = { status: 429, headers: {} };
+    const fn = jest.fn().mockRejectedValue(err);
+    const classify = jest.fn().mockReturnValue({ retryable: true });
+
+    const promise = withThrottleRetry(fn, classify);
+    await flushRetries();
+    await expect(promise).rejects.toThrow('still throttled');
+    expect(fn).toHaveBeenCalledTimes(MAX_RETRY_ATTEMPTS + 1);
+  });
+
+  test('stops retrying once the shared budget is exhausted, even with attempts remaining', async () => {
+    const fn = jest.fn().mockResolvedValue({ status: 429 });
+    const classify = jest.fn().mockReturnValue({ retryable: true, retryAfter: undefined });
+    const budget = createRetryBudget(100); // smaller than a single backoff delay (500ms)
+
+    const promise = withThrottleRetry(fn, classify, { budget });
+    await flushRetries();
+    const result = await promise;
+
+    // First attempt fails, budget check happens before sleeping the 500ms
+    // backoff — since budget.limitMs (100) is below BASE_BACKOFF_MS (500),
+    // the very first retry already exceeds it once spent, so this should
+    // stop well short of MAX_RETRY_ATTEMPTS + 1 real attempts.
+    expect(result).toEqual({ status: 429 });
+    expect(fn.mock.calls.length).toBeLessThanOrEqual(MAX_RETRY_ATTEMPTS + 1);
+    expect(budget.spentMs).toBeGreaterThan(0);
+  });
+
+  test('shares budget across multiple independent withThrottleRetry calls', async () => {
+    const budget = createRetryBudget(600); // just over one 500ms backoff
+    const classify = jest.fn().mockReturnValue({ retryable: true });
+
+    const fn1 = jest.fn().mockResolvedValue({ status: 429 });
+    const promise1 = withThrottleRetry(fn1, classify, { budget });
+    await flushRetries();
+    await promise1;
+
+    const spentAfterFirst = budget.spentMs;
+    expect(spentAfterFirst).toBeGreaterThan(0);
+
+    // Second call starts with the budget already (mostly) spent — should
+    // retry less than a fresh call would.
+    const fn2 = jest.fn().mockResolvedValue({ status: 429 });
+    const promise2 = withThrottleRetry(fn2, classify, { budget });
+    await flushRetries();
+    await promise2;
+
+    expect(fn2.mock.calls.length).toBeLessThanOrEqual(fn1.mock.calls.length);
+  });
+});

--- a/src/test/util/authCallbackPage.test.ts
+++ b/src/test/util/authCallbackPage.test.ts
@@ -1,0 +1,54 @@
+import { buildCallbackPage } from '../../util/authCallbackPage';
+
+describe('buildCallbackPage', () => {
+  test('embeds the exact validated target origin, not a wildcard', () => {
+    const { html } = buildCallbackPage({
+      targetOrigin: 'https://docgen.example.com',
+      payload: { type: 'docgen:sp-auth', ok: true, handleCode: 'abc123' },
+    });
+    expect(html).toContain('"https://docgen.example.com"');
+    expect(html).not.toMatch(/postMessage\([^)]*['"]\*['"]\)/);
+  });
+
+  test('never embeds the word "token" or "accessToken" in the page (no token in the postMessage payload)', () => {
+    const { html } = buildCallbackPage({
+      targetOrigin: 'https://docgen.example.com',
+      payload: { type: 'docgen:sp-auth', ok: true, handleCode: 'one-time-handle' },
+    });
+    expect(html.toLowerCase()).not.toContain('accesstoken');
+    expect(html.toLowerCase()).not.toContain('refreshtoken');
+  });
+
+  test('carries the discriminator type and ok flag through to the payload', () => {
+    const { html } = buildCallbackPage({
+      targetOrigin: 'https://docgen.example.com',
+      payload: { type: 'docgen:sp-auth', ok: false, error: 'access_denied' },
+    });
+    expect(html).toContain('docgen:sp-auth');
+    expect(html).toContain('access_denied');
+  });
+
+  test('sets a restrictive CSP with a nonce and X-Frame-Options: DENY', () => {
+    const { headers } = buildCallbackPage({
+      targetOrigin: 'https://docgen.example.com',
+      payload: { type: 'docgen:sp-auth', ok: true },
+    });
+    expect(headers['Content-Security-Policy']).toMatch(/default-src 'none'/);
+    expect(headers['Content-Security-Policy']).toMatch(/script-src 'nonce-[A-Za-z0-9+/=]+'/);
+    expect(headers['X-Frame-Options']).toBe('DENY');
+  });
+
+  test('produces a different nonce on each call', () => {
+    const first = buildCallbackPage({ targetOrigin: 'https://a.example.com', payload: { type: 'docgen:sp-auth', ok: true } });
+    const second = buildCallbackPage({ targetOrigin: 'https://a.example.com', payload: { type: 'docgen:sp-auth', ok: true } });
+    expect(first.headers['Content-Security-Policy']).not.toBe(second.headers['Content-Security-Policy']);
+  });
+
+  test('escapes a "</script>" sequence in an error string so it cannot break out of the inline script', () => {
+    const { html } = buildCallbackPage({
+      targetOrigin: 'https://docgen.example.com',
+      payload: { type: 'docgen:sp-auth', ok: false, error: '</script><script>alert(1)</script>' },
+    });
+    expect(html).not.toContain('</script><script>alert(1)</script>');
+  });
+});

--- a/src/test/util/authConfig.test.ts
+++ b/src/test/util/authConfig.test.ts
@@ -1,0 +1,116 @@
+import { getAuthConfig, getAllowedOrigins, assertAuthConfig, resetAuthConfigCacheForTests } from '../../util/authConfig';
+
+const REQUIRED_VARS = ['CLIENT_ID', 'TENANT_ID', 'CLIENT_SECRET', 'REDIRECT_URI', 'SESSION_SECRET'];
+const VALID_SESSION_SECRET = 'a'.repeat(32);
+
+function setValidEnv(overrides: Record<string, string | undefined> = {}) {
+  process.env.CLIENT_ID = overrides.CLIENT_ID ?? 'client-123';
+  process.env.TENANT_ID = overrides.TENANT_ID ?? 'tenant-456';
+  process.env.CLIENT_SECRET = overrides.CLIENT_SECRET ?? 'secret-789';
+  process.env.REDIRECT_URI = overrides.REDIRECT_URI ?? 'https://docgen.example.com/auth/callback';
+  process.env.SESSION_SECRET = overrides.SESSION_SECRET ?? VALID_SESSION_SECRET;
+}
+
+describe('authConfig', () => {
+  beforeEach(() => {
+    resetAuthConfigCacheForTests();
+    for (const name of REQUIRED_VARS) delete process.env[name];
+    delete process.env.CORS_ALLOWED_ORIGINS;
+  });
+
+  describe('getAuthConfig', () => {
+    test('returns the parsed config when every var is present and valid', () => {
+      setValidEnv();
+      expect(getAuthConfig()).toEqual({
+        clientId: 'client-123',
+        tenantId: 'tenant-456',
+        clientSecret: 'secret-789',
+        redirectUri: 'https://docgen.example.com/auth/callback',
+        sessionSecret: VALID_SESSION_SECRET,
+      });
+    });
+
+    test.each(REQUIRED_VARS)('throws when %s is missing', (missingVar) => {
+      setValidEnv();
+      delete process.env[missingVar];
+      expect(() => getAuthConfig()).toThrow(new RegExp(missingVar));
+    });
+
+    test.each(REQUIRED_VARS)('throws when %s is blank', (blankVar) => {
+      setValidEnv({ [blankVar]: '   ' });
+      expect(() => getAuthConfig()).toThrow(new RegExp(blankVar));
+    });
+
+    test('rejects a non-https, non-localhost REDIRECT_URI', () => {
+      setValidEnv({ REDIRECT_URI: 'http://docgen.example.com/auth/callback' });
+      expect(() => getAuthConfig()).toThrow(/must be https/i);
+    });
+
+    test('accepts http://localhost as the documented Entra exception', () => {
+      setValidEnv({ REDIRECT_URI: 'http://localhost:30001/auth/callback' });
+      expect(() => getAuthConfig()).not.toThrow();
+    });
+
+    test('accepts http://127.0.0.1', () => {
+      setValidEnv({ REDIRECT_URI: 'http://127.0.0.1:30001/auth/callback' });
+      expect(() => getAuthConfig()).not.toThrow();
+    });
+
+    test('rejects an unparsable REDIRECT_URI', () => {
+      setValidEnv({ REDIRECT_URI: 'not-a-url' });
+      expect(() => getAuthConfig()).toThrow(/not a valid URL/i);
+    });
+
+    test('rejects a SESSION_SECRET shorter than 32 characters', () => {
+      setValidEnv({ SESSION_SECRET: 'too-short' });
+      expect(() => getAuthConfig()).toThrow(/at least 32 characters/i);
+    });
+
+    test('memoizes after the first successful call', () => {
+      setValidEnv();
+      const first = getAuthConfig();
+      process.env.CLIENT_ID = 'changed-after-first-call';
+      const second = getAuthConfig();
+      expect(second).toBe(first);
+      expect(second.clientId).toBe('client-123');
+    });
+  });
+
+  describe('getAllowedOrigins', () => {
+    test('returns an empty array when unset (deny-all default, not allow-all)', () => {
+      expect(getAllowedOrigins()).toEqual([]);
+    });
+
+    test('parses a comma-separated list and trims whitespace', () => {
+      process.env.CORS_ALLOWED_ORIGINS = ' https://a.example.com , https://b.example.com ';
+      expect(getAllowedOrigins()).toEqual(['https://a.example.com', 'https://b.example.com']);
+    });
+
+    test('drops empty entries from stray commas', () => {
+      process.env.CORS_ALLOWED_ORIGINS = 'https://a.example.com,,';
+      expect(getAllowedOrigins()).toEqual(['https://a.example.com']);
+    });
+
+    test('throws if the list contains a bare wildcard', () => {
+      process.env.CORS_ALLOWED_ORIGINS = 'https://a.example.com,*';
+      expect(() => getAllowedOrigins()).toThrow(/must not include/i);
+    });
+  });
+
+  describe('assertAuthConfig', () => {
+    test('does not throw when everything is valid', () => {
+      setValidEnv();
+      expect(() => assertAuthConfig()).not.toThrow();
+    });
+
+    test('throws when the base config is invalid', () => {
+      expect(() => assertAuthConfig()).toThrow();
+    });
+
+    test('throws when CORS_ALLOWED_ORIGINS contains a wildcard even if the base config is valid', () => {
+      setValidEnv();
+      process.env.CORS_ALLOWED_ORIGINS = '*';
+      expect(() => assertAuthConfig()).toThrow(/must not include/i);
+    });
+  });
+});

--- a/src/test/util/cookies.test.ts
+++ b/src/test/util/cookies.test.ts
@@ -1,0 +1,143 @@
+import {
+  parseCookieHeader,
+  sessionCookieOptions,
+  clearedSessionCookieOptions,
+  sessionCookieName,
+  csrfCookieName,
+  csrfCookieOptions,
+  clearedCsrfCookieOptions,
+  preAuthCookieName,
+  preAuthCookieOptions,
+  clearedPreAuthCookieOptions,
+} from '../../util/cookies';
+
+describe('cookies', () => {
+  describe('parseCookieHeader', () => {
+    test('returns an empty object for an undefined header', () => {
+      expect(parseCookieHeader(undefined)).toEqual({});
+    });
+
+    test('returns an empty object for an empty header', () => {
+      expect(parseCookieHeader('')).toEqual({});
+    });
+
+    test('parses a single cookie', () => {
+      expect(parseCookieHeader('foo=bar')).toEqual({ foo: 'bar' });
+    });
+
+    test('parses multiple cookies separated by "; "', () => {
+      expect(parseCookieHeader('foo=bar; baz=qux')).toEqual({ foo: 'bar', baz: 'qux' });
+    });
+
+    test('handles duplicate cookie names by keeping the last value', () => {
+      expect(parseCookieHeader('foo=first; foo=second')).toEqual({ foo: 'second' });
+    });
+
+    test('strips surrounding quotes from a quoted value', () => {
+      expect(parseCookieHeader('foo="bar"')).toEqual({ foo: 'bar' });
+    });
+
+    test('URL-decodes percent-encoded values', () => {
+      expect(parseCookieHeader('foo=a%20b%3Dc')).toEqual({ foo: 'a b=c' });
+    });
+
+    test('falls back to the raw value on a malformed percent-escape instead of throwing', () => {
+      expect(() => parseCookieHeader('foo=%')).not.toThrow();
+      expect(parseCookieHeader('foo=%')).toEqual({ foo: '%' });
+    });
+
+    test('ignores segments with no "=" separator', () => {
+      expect(parseCookieHeader('foo=bar; malformed; baz=qux')).toEqual({ foo: 'bar', baz: 'qux' });
+    });
+
+    test('ignores an entry with an empty name', () => {
+      expect(parseCookieHeader('=novalue; foo=bar')).toEqual({ foo: 'bar' });
+    });
+  });
+
+  describe('sessionCookieOptions', () => {
+    test('sets HttpOnly, Secure, SameSite=None, Path=/, and no Domain', () => {
+      const options = sessionCookieOptions(60_000);
+      expect(options).toMatchObject({
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+        path: '/',
+        maxAge: 60_000,
+      });
+      expect(options).not.toHaveProperty('domain');
+    });
+  });
+
+  describe('clearedSessionCookieOptions', () => {
+    test('sets maxAge to 0 while keeping the same security attributes', () => {
+      const options = clearedSessionCookieOptions();
+      expect(options).toMatchObject({
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+        path: '/',
+        maxAge: 0,
+      });
+      expect(options).not.toHaveProperty('domain');
+    });
+  });
+
+  test('sessionCookieName uses the __Host- prefix', () => {
+    expect(sessionCookieName.startsWith('__Host-')).toBe(true);
+  });
+
+  describe('csrfCookieOptions', () => {
+    test('is deliberately NOT HttpOnly (client JS must read it to echo as a header), but still Secure/SameSite=None', () => {
+      const options = csrfCookieOptions(60_000);
+      expect(options).toMatchObject({
+        httpOnly: false,
+        secure: true,
+        sameSite: 'none',
+        path: '/',
+        maxAge: 60_000,
+      });
+    });
+  });
+
+  describe('clearedCsrfCookieOptions', () => {
+    test('sets maxAge to 0 while keeping httpOnly:false', () => {
+      const options = clearedCsrfCookieOptions();
+      expect(options).toMatchObject({ httpOnly: false, secure: true, sameSite: 'none', maxAge: 0 });
+    });
+  });
+
+  test('csrfCookieName is distinct from sessionCookieName and does not use the __Host- prefix (not needed — it is not the auth credential)', () => {
+    expect(csrfCookieName).not.toBe(sessionCookieName);
+  });
+
+  describe('preAuthCookieOptions', () => {
+    test('uses SameSite=Lax (not None) — sufficient for a top-level GET callback navigation, unlike the session cookie', () => {
+      const options = preAuthCookieOptions();
+      expect(options).toMatchObject({
+        httpOnly: true,
+        secure: true,
+        sameSite: 'lax',
+        path: '/',
+      });
+      expect(options).not.toHaveProperty('domain');
+    });
+
+    test('sets a maxAge matching the 10-minute OAuthTransaction TTL', () => {
+      const options = preAuthCookieOptions();
+      expect(options.maxAge).toBe(10 * 60 * 1000);
+    });
+  });
+
+  describe('clearedPreAuthCookieOptions', () => {
+    test('sets maxAge to 0 while keeping SameSite=Lax', () => {
+      const options = clearedPreAuthCookieOptions();
+      expect(options).toMatchObject({ httpOnly: true, secure: true, sameSite: 'lax', maxAge: 0 });
+    });
+  });
+
+  test('preAuthCookieName uses the __Host- prefix and is distinct from the session cookie', () => {
+    expect(preAuthCookieName.startsWith('__Host-')).toBe(true);
+    expect(preAuthCookieName).not.toBe(sessionCookieName);
+  });
+});

--- a/src/test/util/graphUrlGuard.test.ts
+++ b/src/test/util/graphUrlGuard.test.ts
@@ -1,0 +1,53 @@
+import { assertGraphApiUrl, assertDownloadUrl } from '../../util/graphUrlGuard';
+
+describe('graphUrlGuard', () => {
+  describe('assertGraphApiUrl (gates @odata.nextLink)', () => {
+    test('accepts a genuine graph.microsoft.com https URL', () => {
+      expect(() => assertGraphApiUrl('https://graph.microsoft.com/v1.0/drives/abc/items/def/children')).not.toThrow();
+    });
+
+    test.each([
+      ['plain http', 'http://graph.microsoft.com/v1.0/drives/abc/children'],
+      ['non-https scheme', 'ftp://graph.microsoft.com/v1.0/drives/abc/children'],
+      ['lookalike subdomain suffix', 'https://graph.microsoft.com.evil.com/v1.0/x'],
+      ['path-embedded lookalike', 'https://evil.com/graph.microsoft.com/v1.0/x'],
+      ['userinfo smuggling', 'https://graph.microsoft.com@evil.com/v1.0/x'],
+      ['completely different host', 'https://attacker.example.com/v1.0/x'],
+      ['malformed URL', 'not a url at all'],
+    ])('rejects %s', (_label, url) => {
+      expect(() => assertGraphApiUrl(url)).toThrow();
+    });
+  });
+
+  describe('assertDownloadUrl (gates @microsoft.graph.downloadUrl)', () => {
+    test.each([
+      ['graph.microsoft.com', 'https://graph.microsoft.com/download/abc'],
+      ['a sharepoint.com subdomain', 'https://contoso.sharepoint.com/download/abc'],
+      ['a sharepoint.us subdomain', 'https://contoso.sharepoint.us/download/abc'],
+      ['a onedrive.com subdomain', 'https://contoso-my.onedrive.com/download/abc'],
+      ['onedrive.live.com', 'https://onedrive.live.com/download/abc'],
+    ])('accepts %s', (_label, url) => {
+      expect(() => assertDownloadUrl(url)).not.toThrow();
+    });
+
+    test.each([
+      ['plain http', 'http://contoso.sharepoint.com/download/abc'],
+      ['localhost', 'https://localhost/download/abc'],
+      ['loopback IPv4', 'https://127.0.0.1/download/abc'],
+      ['loopback IPv6', 'https://[::1]/download/abc'],
+      ['private 10.x', 'https://10.0.0.5/download/abc'],
+      ['private 172.16-31.x', 'https://172.20.0.5/download/abc'],
+      ['private 192.168.x', 'https://192.168.1.5/download/abc'],
+      ['link-local / cloud metadata', 'https://169.254.169.254/latest/meta-data/'],
+      ['userinfo smuggling', 'https://graph.microsoft.com@evil.com/download/abc'],
+      ['unrecognized host', 'https://attacker.example.com/download/abc'],
+      ['malformed URL', 'not a url at all'],
+    ])('rejects %s', (_label, url) => {
+      expect(() => assertDownloadUrl(url)).toThrow();
+    });
+
+    test('does not treat a suffix-lookalike host as a sharepoint.com subdomain', () => {
+      expect(() => assertDownloadUrl('https://evilsharepoint.com/download/abc')).toThrow();
+    });
+  });
+});

--- a/src/test/util/randomTokens.test.ts
+++ b/src/test/util/randomTokens.test.ts
@@ -1,0 +1,59 @@
+import { newOpaqueToken, hashToken, timingSafeEqualStr } from '../../util/randomTokens';
+
+describe('randomTokens', () => {
+  describe('newOpaqueToken', () => {
+    test('returns a base64url string with no padding/plus/slash characters', () => {
+      const token = newOpaqueToken();
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    test('32 bytes decodes to a 43-character token (RFC 7636 PKCE verifier range)', () => {
+      const token = newOpaqueToken(32);
+      expect(token.length).toBe(43);
+    });
+
+    test('respects a custom byte length', () => {
+      const token = newOpaqueToken(16);
+      expect(token.length).toBe(22);
+    });
+
+    test('is not deterministic across calls', () => {
+      const a = newOpaqueToken();
+      const b = newOpaqueToken();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('hashToken', () => {
+    test('is deterministic for the same input', () => {
+      expect(hashToken('same-input')).toBe(hashToken('same-input'));
+    });
+
+    test('differs for different inputs', () => {
+      expect(hashToken('input-a')).not.toBe(hashToken('input-b'));
+    });
+
+    test('returns a 64-character hex sha256 digest', () => {
+      expect(hashToken('anything')).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+
+  describe('timingSafeEqualStr', () => {
+    test('returns true for equal strings', () => {
+      expect(timingSafeEqualStr('abc123', 'abc123')).toBe(true);
+    });
+
+    test('returns false for different same-length strings', () => {
+      expect(timingSafeEqualStr('abc123', 'abc124')).toBe(false);
+    });
+
+    test('returns false for different-length strings without throwing', () => {
+      expect(() => timingSafeEqualStr('short', 'a-much-longer-string')).not.toThrow();
+      expect(timingSafeEqualStr('short', 'a-much-longer-string')).toBe(false);
+    });
+
+    test('returns false comparing against an empty string', () => {
+      expect(timingSafeEqualStr('nonempty', '')).toBe(false);
+    });
+  });
+});

--- a/src/test/util/sharePointLinkClassifier.test.ts
+++ b/src/test/util/sharePointLinkClassifier.test.ts
@@ -1,0 +1,54 @@
+import { classifySharePointUrl } from '../../util/sharePointLinkClassifier';
+
+describe('classifySharePointUrl', () => {
+  test('classifies a non-SharePoint-Online host as onprem', () => {
+    expect(classifySharePointUrl({ siteUrl: 'http://sp-server.internal/sites/projectx' })).toBe('onprem');
+  });
+
+  test('classifies a "Copy Link" sharing URL as online-sharing-link', () => {
+    expect(
+      classifySharePointUrl({
+        siteUrl: 'https://contoso.sharepoint.com/:f:/r/teams/x/Shared%20Documents/y?d=abc123',
+      })
+    ).toBe('online-sharing-link');
+  });
+
+  test('classifies a 1drv.ms short link as online-sharing-link', () => {
+    expect(classifySharePointUrl({ siteUrl: 'https://1drv.ms/f/s!abc123' })).toBe('online-sharing-link');
+  });
+
+  test('classifies the empirically-validated address-bar id= shape as online-sharing-link, not legacy', () => {
+    // This exact shape (from the live spike this session) resolved
+    // successfully via /shares under Files.Read.All alone — it must NOT be
+    // flagged for relink.
+    const siteUrl =
+      'https://korentec-my.sharepoint.com/shared?id=%2Fsites%2FDocgen%2FShared%20Documents%2Fshared&listurl=https%3A%2F%2Fkorentec.sharepoint.com%2Fsites%2FDocgen%2FShared%20Documents';
+    expect(classifySharePointUrl({ siteUrl })).toBe('online-sharing-link');
+  });
+
+  test('classifies an Online row with a populated library/folder split as online-legacy-site-path', () => {
+    expect(
+      classifySharePointUrl({
+        siteUrl: 'https://contoso.sharepoint.com/sites/projectx',
+        library: 'Shared Documents',
+        folder: 'Templates/STD',
+      })
+    ).toBe('online-legacy-site-path');
+  });
+
+  test('classifies a bare Online site URL with no addressing at all as online-legacy-site-path', () => {
+    expect(classifySharePointUrl({ siteUrl: 'https://contoso.sharepoint.com/sites/projectx' })).toBe('online-legacy-site-path');
+  });
+
+  test('classifies an unparsable URL as online-legacy-site-path (conservative default)', () => {
+    expect(classifySharePointUrl({ siteUrl: 'not a url' })).toBe('online-legacy-site-path');
+  });
+
+  test('classifies a deep Online path with no id param as online-sharing-link (has content addressing)', () => {
+    expect(
+      classifySharePointUrl({
+        siteUrl: 'https://contoso.sharepoint.com/sites/projectx/Shared%20Documents/Forms/AllItems.aspx',
+      })
+    ).toBe('online-sharing-link');
+  });
+});

--- a/src/test/util/tokenCacheCipher.test.ts
+++ b/src/test/util/tokenCacheCipher.test.ts
@@ -1,0 +1,62 @@
+import { encryptCacheBlob, decryptCacheBlob, CURRENT_KEY_VERSION } from '../../util/tokenCacheCipher';
+import { resetAuthConfigCacheForTests } from '../../util/authConfig';
+
+const VALID_SESSION_SECRET = 'b'.repeat(32);
+
+describe('tokenCacheCipher', () => {
+  beforeEach(() => {
+    resetAuthConfigCacheForTests();
+    process.env.CLIENT_ID = 'client';
+    process.env.TENANT_ID = 'tenant';
+    process.env.CLIENT_SECRET = 'secret';
+    process.env.REDIRECT_URI = 'https://docgen.example.com/auth/callback';
+    process.env.SESSION_SECRET = VALID_SESSION_SECRET;
+  });
+
+  test('round-trips plaintext through encrypt then decrypt', () => {
+    const plaintext = JSON.stringify({ hello: 'world', tokens: ['a', 'b'] });
+    const blob = encryptCacheBlob(plaintext);
+    expect(decryptCacheBlob(blob)).toBe(plaintext);
+  });
+
+  test('encrypted blob does not contain the plaintext', () => {
+    const plaintext = 'a-very-recognizable-secret-marker';
+    const blob = encryptCacheBlob(plaintext);
+    expect(blob.ciphertext).not.toContain(plaintext);
+  });
+
+  test('records the key version used', () => {
+    const blob = encryptCacheBlob('anything');
+    expect(blob.keyVersion).toBe(CURRENT_KEY_VERSION);
+  });
+
+  test('produces a different ciphertext each time (random IV)', () => {
+    const a = encryptCacheBlob('same plaintext');
+    const b = encryptCacheBlob('same plaintext');
+    expect(a.ciphertext).not.toBe(b.ciphertext);
+    expect(a.iv).not.toBe(b.iv);
+  });
+
+  test('throws when the authTag has been tampered with', () => {
+    const blob = encryptCacheBlob('sensitive data');
+    const tampered = { ...blob, authTag: Buffer.from('0'.repeat(32), 'hex').toString('base64') };
+    expect(() => decryptCacheBlob(tampered)).toThrow();
+  });
+
+  test('throws when the ciphertext has been tampered with', () => {
+    const blob = encryptCacheBlob('sensitive data');
+    const tamperedBytes = Buffer.from(blob.ciphertext, 'base64');
+    tamperedBytes[0] = tamperedBytes[0] ^ 0xff;
+    const tampered = { ...blob, ciphertext: tamperedBytes.toString('base64') };
+    expect(() => decryptCacheBlob(tampered)).toThrow();
+  });
+
+  test('throws when decrypted under a different SESSION_SECRET (simulated via wrong keyVersion input path)', () => {
+    const blob = encryptCacheBlob('secret payload');
+    // Same keyVersion number but a different underlying secret should fail
+    // to decrypt — simulate by changing the secret after encrypting.
+    resetAuthConfigCacheForTests();
+    process.env.SESSION_SECRET = 'c'.repeat(32);
+    expect(() => decryptCacheBlob(blob)).toThrow();
+  });
+});

--- a/src/test/utils/testResponse.ts
+++ b/src/test/utils/testResponse.ts
@@ -3,12 +3,40 @@ export function buildRes() {
   const res: any = {};
   res.statusCode = 200;
   res.body = undefined;
+  res.text = undefined;
+  res.cookies = {} as Record<string, { value: string; options: any }>;
+  res.clearedCookies = [] as string[];
+  res.redirectedTo = undefined as string | undefined;
+  res.headers = {} as Record<string, string>;
   res.status = jest.fn((code: number) => {
     res.statusCode = code;
     return res;
   });
   res.json = jest.fn((body: any) => {
     res.body = body;
+    return res;
+  });
+  // Chainable stand-ins for the auth flow's cookie/redirect/raw-HTML
+  // response methods — additive to the existing status/json pair so
+  // pre-existing controller tests using only those are unaffected.
+  res.cookie = jest.fn((name: string, value: string, options: any) => {
+    res.cookies[name] = { value, options };
+    return res;
+  });
+  res.clearCookie = jest.fn((name: string, _options?: any) => {
+    res.clearedCookies.push(name);
+    return res;
+  });
+  res.redirect = jest.fn((url: string) => {
+    res.redirectedTo = url;
+    return res;
+  });
+  res.set = jest.fn((headers: Record<string, string>) => {
+    Object.assign(res.headers, headers);
+    return res;
+  });
+  res.send = jest.fn((body: any) => {
+    res.text = body;
     return res;
   });
   return res;

--- a/src/util/authCallbackPage.ts
+++ b/src/util/authCallbackPage.ts
@@ -1,0 +1,74 @@
+// Builds the tiny HTML page the OAuth popup lands on after /auth/callback
+// finishes. Its only job is to postMessage the result back to the window
+// that opened it, to a validated target origin, then close itself. A popup
+// is required because Entra's login page refuses to be iframed; the target
+// origin must never be caller-supplied.
+//
+// Kept as a pure string builder (no Express Response touched here) so the
+// security-critical origin-pinning and payload shape are directly
+// unit-testable without spinning up HTTP.
+import { randomBytes } from 'crypto';
+
+export interface AuthCallbackPagePayload {
+  type: 'docgen:sp-auth';
+  ok: boolean;
+  handleCode?: string;
+  error?: string;
+  errorDescription?: string;
+}
+
+export interface BuildCallbackPageInput {
+  targetOrigin: string;
+  payload: AuthCallbackPagePayload;
+}
+
+export interface BuildCallbackPageResult {
+  html: string;
+  headers: Record<string, string>;
+}
+
+function escapeForInlineScript(value: string): string {
+  // JSON.stringify already escapes quotes/backslashes/control chars; the
+  // remaining risk is a literal "</script>" sequence breaking out of the
+  // inline <script> block, so that's escaped separately.
+  return JSON.stringify(value).replace(/</g, '\\u003C');
+}
+
+const SCRIPT_NONCE_BYTES = 16;
+
+export function buildCallbackPage({ targetOrigin, payload }: BuildCallbackPageInput): BuildCallbackPageResult {
+  const nonce = randomBytes(SCRIPT_NONCE_BYTES).toString('base64');
+
+  // The payload never carries a Graph token, refresh token, or session
+  // cookie value — only a boolean, an optional one-time handle code, and
+  // optional error strings. This is deliberate: postMessage payloads are
+  // observable by any script running in the popup's origin.
+  const serializedPayload = escapeForInlineScript(JSON.stringify(payload));
+  const serializedTargetOrigin = escapeForInlineScript(targetOrigin);
+
+  const html = `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Signing in…</title></head>
+<body>
+<script nonce="${nonce}">
+  (function () {
+    var targetOrigin = ${serializedTargetOrigin};
+    var payload = JSON.parse(${serializedPayload});
+    if (window.opener) {
+      window.opener.postMessage(payload, targetOrigin);
+    }
+    window.close();
+  })();
+</script>
+</body>
+</html>`;
+
+  return {
+    html,
+    headers: {
+      'Content-Security-Policy': `default-src 'none'; script-src 'nonce-${nonce}'`,
+      'X-Frame-Options': 'DENY',
+      'Content-Type': 'text/html; charset=utf-8',
+    },
+  };
+}

--- a/src/util/authConfig.ts
+++ b/src/util/authConfig.ts
@@ -1,0 +1,96 @@
+// Reads and validates the SharePoint-Online OAuth (BFF) environment once,
+// then freezes the result. Two entry points exist deliberately:
+//
+//  - getAuthConfig() / getAllowedOrigins(): lenient-on-import, throw only
+//    when actually called. app.ts calls getAllowedOrigins() during CORS
+//    setup, which existing tests construct with no env at all (see
+//    JsonDocRoutes.test.ts) — those calls must not explode at module load.
+//  - assertAuthConfig(): the loud, fail-fast boot check. server.ts calls
+//    this before connectToDatabase() so a misconfigured deployment (missing
+//    CLIENT_SECRET, an http:// REDIRECT_URI, etc.) refuses to start instead
+//    of silently limping along with a broken auth flow.
+export interface AuthConfig {
+  clientId: string;
+  tenantId: string;
+  clientSecret: string;
+  redirectUri: string;
+  sessionSecret: string;
+}
+
+let cachedConfig: AuthConfig | null = null;
+
+function readRequired(name: string): string {
+  const value = process.env[name];
+  if (!value || !value.trim()) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value.trim();
+}
+
+// Entra rejects non-https redirect URIs except for the documented
+// http://localhost exception (any port) — used for local/dev simulation
+// against docker-compose. See the plan's "Environment variables" section.
+function assertRedirectUriIsSecureOrLocalhost(redirectUri: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(redirectUri);
+  } catch {
+    throw new Error(`REDIRECT_URI is not a valid URL: ${redirectUri}`);
+  }
+  const isHttps = parsed.protocol === 'https:';
+  const isLocalhost = parsed.protocol === 'http:' && (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1');
+  if (!isHttps && !isLocalhost) {
+    throw new Error(`REDIRECT_URI must be https:// (or http://localhost for local development): ${redirectUri}`);
+  }
+}
+
+export function getAuthConfig(): AuthConfig {
+  if (cachedConfig) return cachedConfig;
+
+  const clientId = readRequired('CLIENT_ID');
+  const tenantId = readRequired('TENANT_ID');
+  const clientSecret = readRequired('CLIENT_SECRET');
+  const redirectUri = readRequired('REDIRECT_URI');
+  const sessionSecret = readRequired('SESSION_SECRET');
+
+  assertRedirectUriIsSecureOrLocalhost(redirectUri);
+  if (sessionSecret.length < 32) {
+    throw new Error('SESSION_SECRET must be at least 32 characters — used to derive the token-cache encryption key');
+  }
+
+  cachedConfig = { clientId, tenantId, clientSecret, redirectUri, sessionSecret };
+  return cachedConfig;
+}
+
+// Unset/empty CORS_ALLOWED_ORIGINS means "no cross-origin request is
+// trusted" — a deliberate change from this codebase's previous behavior,
+// where an unset value meant "allow every origin". That old default is not
+// safe once cors() is also configured with credentials:true (see app.ts) —
+// allow-all plus credentials is a session-theft hole, not a convenience.
+//
+// '*' is rejected outright rather than silently treated as allow-all: the
+// cors package itself refuses to combine a literal '*' origin with
+// credentials, so accepting it here would just move the failure somewhere
+// more confusing.
+export function getAllowedOrigins(): string[] {
+  const origins = String(process.env.CORS_ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  if (origins.includes('*')) {
+    throw new Error("CORS_ALLOWED_ORIGINS must not include '*' — credentialed requests require an explicit origin allowlist");
+  }
+  return origins;
+}
+
+export function assertAuthConfig(): void {
+  getAuthConfig();
+  getAllowedOrigins();
+}
+
+// Test-only: getAuthConfig() memoizes on first call, which would otherwise
+// leak one test's env vars into the next.
+export function resetAuthConfigCacheForTests(): void {
+  cachedConfig = null;
+}

--- a/src/util/cookies.ts
+++ b/src/util/cookies.ts
@@ -1,0 +1,110 @@
+// Cookie header parsing + the canonical session-cookie option builder.
+// Deliberately no `cookie-parser` dependency — reading a `Cookie` header is
+// a handful of lines, and keeping it here means the whole BFF auth feature
+// adds zero new backend packages (see the plan's Finding 1).
+import { CookieOptions } from 'express';
+
+export const sessionCookieName = '__Host-docgen_sp_session';
+
+export function parseCookieHeader(header: string | undefined | null): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (!header) return result;
+
+  for (const part of header.split(';')) {
+    const eqIndex = part.indexOf('=');
+    if (eqIndex === -1) continue;
+    const rawName = part.slice(0, eqIndex).trim();
+    if (!rawName) continue;
+    const rawValue = part.slice(eqIndex + 1).trim().replace(/^"(.*)"$/, '$1');
+    try {
+      result[rawName] = decodeURIComponent(rawValue);
+    } catch {
+      // A malformed %-escape shouldn't crash cookie parsing for every other
+      // cookie on the request — fall back to the raw value for this one.
+      result[rawName] = rawValue;
+    }
+  }
+  return result;
+}
+
+// `SameSite=None` is mandatory, not a preference: the OAuth callback is a
+// cross-site top-level navigation from login.microsoftonline.com, and the
+// ADO-embedded iframe's calls are cross-site sub-resource requests. This
+// gives zero CSRF protection on its own — see requireCsrf.ts for that.
+//
+// No `domain` attribute is set anywhere — required by the `__Host-` cookie
+// name prefix, which browsers enforce: Secure + Path=/ + no Domain, or the
+// Set-Cookie is silently rejected entirely.
+export function sessionCookieOptions(maxAgeMs: number): CookieOptions {
+  return {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
+    path: '/',
+    maxAge: maxAgeMs,
+  };
+}
+
+export function clearedSessionCookieOptions(): CookieOptions {
+  return {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
+    path: '/',
+    maxAge: 0,
+  };
+}
+
+// The double-submit CSRF cookie. Deliberately NOT HttpOnly — client JS must
+// read it and echo it back as the X-Csrf-Token header; its value is
+// meaningless to an attacker who can't also set a custom header, which a
+// cross-site form/img/link request can't do. `__Host-` prefixed like the
+// session cookie above — Secure + Path=/ + no Domain already satisfy it.
+export const csrfCookieName = '__Host-docgen_csrf';
+
+export function csrfCookieOptions(maxAgeMs: number): CookieOptions {
+  return {
+    httpOnly: false,
+    secure: true,
+    sameSite: 'none',
+    path: '/',
+    maxAge: maxAgeMs,
+  };
+}
+
+export function clearedCsrfCookieOptions(): CookieOptions {
+  return {
+    httpOnly: false,
+    secure: true,
+    sameSite: 'none',
+    path: '/',
+    maxAge: 0,
+  };
+}
+
+// The short-lived pre-auth cookie: set at GET /auth/login, checked at
+// GET /auth/callback as the login-CSRF defense. SameSite=Lax is enough
+// here because the callback arrives as a top-level GET navigation from
+// login.microsoftonline.com, which Lax permits.
+export const preAuthCookieName = '__Host-docgen_preauth';
+const PRE_AUTH_MAX_AGE_MS = 10 * 60 * 1000; // matches OAuthTransaction's TTL
+
+export function preAuthCookieOptions(): CookieOptions {
+  return {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: PRE_AUTH_MAX_AGE_MS,
+  };
+}
+
+export function clearedPreAuthCookieOptions(): CookieOptions {
+  return {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  };
+}

--- a/src/util/graphUrlGuard.ts
+++ b/src/util/graphUrlGuard.ts
@@ -1,0 +1,66 @@
+// Host-allowlist validators guarding every outbound URL Graph itself
+// supplied (rather than one we constructed) — `@odata.nextLink` pagination
+// and `@microsoft.graph.downloadUrl`. A response body is not a trusted
+// input; following either blindly is an SSRF gap.
+const GRAPH_HOSTNAME = 'graph.microsoft.com';
+const DOWNLOAD_HOST_SUFFIXES = ['sharepoint.com', 'sharepointonline.com', 'sharepoint.us', 'onedrive.com', 'onedrive.live.com'];
+
+function isPrivateOrLoopbackHost(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  return (
+    lower === 'localhost' ||
+    lower === '::1' ||
+    /^127\./.test(lower) ||
+    /^10\./.test(lower) ||
+    /^172\.(1[6-9]|2\d|3[0-1])\./.test(lower) ||
+    /^192\.168\./.test(lower) ||
+    /^169\.254\./.test(lower) // link-local, incl. cloud metadata endpoints
+  );
+}
+
+// A URL like `https://graph.microsoft.com@evil.com/` parses with
+// `hostname === 'evil.com'` and `username === 'graph.microsoft.com'` under
+// WHATWG URL semantics — checking `.hostname` alone (never `.href` or a
+// substring/regex match on the raw string) already defeats this userinfo-
+// smuggling shape. Callers must always go through these asserts rather
+// than hand-rolling a check on the raw string.
+function parseOrThrow(url: string, label: string): URL {
+  try {
+    return new URL(url);
+  } catch {
+    throw new Error(`Refusing to follow a malformed ${label}: ${url}`);
+  }
+}
+
+// Gates every `@odata.nextLink` before it is fetched. Exact-hostname match
+// only — no suffix matching — since this is specifically the Graph API
+// endpoint, not a wildcard Microsoft domain.
+export function assertGraphApiUrl(url: string): void {
+  const parsed = parseOrThrow(url, 'Graph URL');
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`Refusing to follow a non-https Graph URL: ${url}`);
+  }
+  if (parsed.hostname.toLowerCase() !== GRAPH_HOSTNAME) {
+    throw new Error(`Refusing to follow a Graph URL pointing outside ${GRAPH_HOSTNAME}: ${url}`);
+  }
+}
+
+// Gates a `@microsoft.graph.downloadUrl` before it is fetched. These are
+// pre-signed URLs pointing at SharePoint/OneDrive's own content hosts (not
+// graph.microsoft.com), so the allowlist is a suffix match across the known
+// content-host families rather than an exact match.
+export function assertDownloadUrl(url: string): void {
+  const parsed = parseOrThrow(url, 'download URL');
+  if (parsed.protocol !== 'https:') {
+    throw new Error('Refusing to fetch a non-https download URL');
+  }
+  const hostname = parsed.hostname.toLowerCase();
+  if (isPrivateOrLoopbackHost(hostname)) {
+    throw new Error('Refusing to fetch a download URL pointing at a private/internal host');
+  }
+  const isAllowedHost =
+    hostname === GRAPH_HOSTNAME || DOWNLOAD_HOST_SUFFIXES.some((suffix) => hostname === suffix || hostname.endsWith(`.${suffix}`));
+  if (!isAllowedHost) {
+    throw new Error(`Refusing to fetch a download URL from an unrecognized host: ${hostname}`);
+  }
+}

--- a/src/util/randomTokens.ts
+++ b/src/util/randomTokens.ts
@@ -1,0 +1,31 @@
+// CSPRNG token minting + comparison helpers shared by every OAuth
+// transaction/session record: `state`, `nonce`, opaque session tokens,
+// handle codes, and CSRF tokens all go through here rather than each
+// caller rolling its own crypto.
+import { randomBytes, createHash, timingSafeEqual } from 'crypto';
+
+// 32 bytes -> 43 base64url chars, well within RFC 7636's 43-128 range for a
+// PKCE code_verifier and plenty of entropy for anything else minted here.
+export function newOpaqueToken(byteLength = 32): string {
+  return randomBytes(byteLength).toString('base64url');
+}
+
+// Only the hash is ever persisted for session/handle tokens (see
+// AuthSession/SessionHandleCode models) — a database dump yields no usable
+// credential.
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+// Constant-time string compare. A length mismatch still runs a same-length
+// dummy comparison so it can't short-circuit into a faster return than a
+// same-length mismatch would — both paths take one full timingSafeEqual call.
+export function timingSafeEqualStr(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, 'utf8');
+  const bufB = Buffer.from(b, 'utf8');
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}

--- a/src/util/sharePointLinkClassifier.ts
+++ b/src/util/sharePointLinkClassifier.ts
@@ -1,0 +1,62 @@
+// Classifies a saved SharePointConfig.siteUrl for the relink-migration UX.
+//
+// Deliberately optimistic, not the source of truth: Graph's /shares
+// endpoint, under a Files.Read.All-only token, resolves both a "Copy Link"
+// sharing URL and a plain browsed-folder address-bar URL, so this trusts
+// almost any Online-host URL by default. `requiresRelink` is only ever
+// authoritatively set by an actual failed /shares resolution at use-time
+// (see SharePointController), never by this static heuristic alone.
+export type SharePointLinkClassification = 'onprem' | 'online-sharing-link' | 'online-legacy-site-path';
+
+// GraphSharePointService's Copy-Link URL shape, e.g.
+// https://tenant.sharepoint.com/:f:/r/...
+const SHARING_LINK_MARKERS = ['/:f:/', '/:w:/', '/:b:/', '/:u:/', '/:x:/', '/:p:/'];
+
+function isOnedriveShortLink(hostname: string): boolean {
+  return hostname.toLowerCase().includes('1drv.ms');
+}
+
+function isSharePointOnlineHost(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  return lower.endsWith('.sharepoint.com') || lower.endsWith('.sharepoint.us') || lower === 'sharepoint.com';
+}
+
+export interface ClassifyInput {
+  siteUrl: string;
+  library?: string;
+  folder?: string;
+}
+
+export function classifySharePointUrl({ siteUrl, library, folder }: ClassifyInput): SharePointLinkClassification {
+  let parsed: URL;
+  try {
+    parsed = new URL(siteUrl);
+  } catch {
+    // Unparsable — can't possibly resolve via /shares either. Conservative
+    // by necessity here, not by assumption.
+    return 'online-legacy-site-path';
+  }
+
+  if (isOnedriveShortLink(parsed.hostname)) return 'online-sharing-link';
+  if (!isSharePointOnlineHost(parsed.hostname)) return 'onprem';
+
+  const hasSharingMarker = SHARING_LINK_MARKERS.some((marker) => parsed.pathname.includes(marker));
+  if (hasSharingMarker) return 'online-sharing-link';
+
+  // SharePointConnectDialog's Online mode only ever has a single shareLink
+  // field — a populated library/folder on an Online row can only come from
+  // an old save shape and can't be resolved from a single pasted URL alone.
+  const hasSeparateLibraryFolder = !!(library && library.trim()) || !!(folder && folder.trim());
+  if (hasSeparateLibraryFolder) return 'online-legacy-site-path';
+
+  // A bare site/library URL with no id= param, no sharing token, and no
+  // library/folder split has nothing for /shares to redeem.
+  const idParam = parsed.searchParams.get('id');
+  const hasContentAddressing = (!!idParam && idParam.startsWith('/')) || parsed.pathname.split('/').filter(Boolean).length > 2;
+  if (!hasContentAddressing) return 'online-legacy-site-path';
+
+  // Anything else on an Online host, including the address-bar
+  // `?id=%2Fsites%2F...` shape, is trusted optimistically — /shares
+  // resolves it.
+  return 'online-sharing-link';
+}

--- a/src/util/tokenCacheCipher.ts
+++ b/src/util/tokenCacheCipher.ts
@@ -1,0 +1,55 @@
+// AES-256-GCM encrypt/decrypt for the serialized MSAL token-cache blob
+// persisted in MsalTokenCache. The key is never stored — it's derived via
+// HKDF from SESSION_SECRET on every call, salted by `keyVersion` so a
+// future secret/key rotation can mint a new key without orphaning rows
+// encrypted under an older version (old rows simply keep their recorded
+// keyVersion and still decrypt correctly).
+import { createCipheriv, createDecipheriv, randomBytes, hkdfSync } from 'crypto';
+import { getAuthConfig } from './authConfig';
+
+export const CURRENT_KEY_VERSION = 1;
+const IV_LENGTH_BYTES = 12; // AES-GCM standard/recommended IV size
+const KEY_LENGTH_BYTES = 32; // AES-256
+
+function deriveKey(keyVersion: number): Buffer {
+  const { sessionSecret } = getAuthConfig();
+  const derived = hkdfSync(
+    'sha256',
+    Buffer.from(sessionSecret, 'utf8'),
+    Buffer.from(`docgen-token-cache-v${keyVersion}`, 'utf8'), // salt
+    Buffer.from('docgen-sharepoint-oauth-cache', 'utf8'), // info
+    KEY_LENGTH_BYTES
+  );
+  return Buffer.from(derived);
+}
+
+export interface EncryptedBlob {
+  ciphertext: string; // base64
+  iv: string; // base64
+  authTag: string; // base64
+  keyVersion: number;
+}
+
+export function encryptCacheBlob(plaintext: string, keyVersion: number = CURRENT_KEY_VERSION): EncryptedBlob {
+  const key = deriveKey(keyVersion);
+  const iv = randomBytes(IV_LENGTH_BYTES);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  return {
+    ciphertext: encrypted.toString('base64'),
+    iv: iv.toString('base64'),
+    authTag: cipher.getAuthTag().toString('base64'),
+    keyVersion,
+  };
+}
+
+// Throws (does not silently return garbage) if `authTag` doesn't match —
+// GCM's whole point is that a tampered ciphertext or a wrong key fails
+// decryption outright rather than yielding corrupted plaintext.
+export function decryptCacheBlob(blob: EncryptedBlob): string {
+  const key = deriveKey(blob.keyVersion);
+  const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(blob.iv, 'base64'));
+  decipher.setAuthTag(Buffer.from(blob.authTag, 'base64'));
+  const decrypted = Buffer.concat([decipher.update(Buffer.from(blob.ciphertext, 'base64')), decipher.final()]);
+  return decrypted.toString('utf8');
+}


### PR DESCRIPTION
  Add Graph-based (Online) SharePoint access alongside NTLM. Scope saved
  SharePoint config by userId only, not per-project, with guards against a
  missing/invalid userId. Reject "shared" as a sync target server-side.
  Propagate each file's real SharePoint modified date into MinIO as custom
  metadata. Surface Graph errors with their real HTTP status instead of a
  flat 500. Fix CORS to allow the X-User-Id header.